### PR TITLE
Sprint 002 B3: Score & Achievement system (#35)

### DIFF
--- a/src/SpaceStationMonitor/Achievements/Achievement.cs
+++ b/src/SpaceStationMonitor/Achievements/Achievement.cs
@@ -1,0 +1,3 @@
+namespace SpaceStationMonitor.Achievements;
+
+public sealed record Achievement(string Name, string Description, Func<Station, bool> Predicate);

--- a/src/SpaceStationMonitor/Achievements/AchievementSystem.cs
+++ b/src/SpaceStationMonitor/Achievements/AchievementSystem.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace SpaceStationMonitor.Achievements;
+
+public class AchievementSystem
+{
+    private readonly HashSet<string> _unlocked = new();
+    private readonly IReadOnlyList<Achievement> _achievements;
+
+    public AchievementSystem()
+    {
+        _achievements = new List<Achievement>
+        {
+            new("FirstRepair",
+                "Complete your first repair.",
+                s => s.RepairsTotalThisSession >= 1),
+
+            new("Centurion",
+                "Survive 100 cycles.",
+                s => s.CycleCount >= 100),
+
+            new("CascadeVeteran",
+                "Survive 5 cascade failures.",
+                s => s.CascadeCount >= 5),
+
+            new("Surgeon",
+                "Average 90% effectiveness across the last 20 repairs.",
+                s => s.RecentRepairEffectiveness.Count >= 20
+                     && s.RecentRepairEffectiveness.Average() >= 90.0),
+
+            new("EmptyTank",
+                "Survive 10 cycles after emergency power runs out.",
+                s => s.EmergencyPowerRemaining == 0
+                     && s.CyclesAfterEmergencyExhausted >= 10),
+
+            new("IronHull",
+                "Hold hull integrity ≥ 80% for 50 consecutive cycles.",
+                s => s.IronHullStreak >= 50),
+
+            new("SolarSurvivor",
+                "Weather a solar flare without any subsystem dropping below 30%.",
+                s => s.SolarFlareThisCycle && s.MinSubsystemStayedAbove30),
+        };
+    }
+
+    public IReadOnlyCollection<string> UnlockedNames => _unlocked;
+
+    public void CheckAndFire(Station station, Activity? cycleSpan, ILogger logger, GameDisplay display)
+    {
+        foreach (var achievement in _achievements)
+        {
+            if (_unlocked.Contains(achievement.Name)) continue;
+            if (!achievement.Predicate(station)) continue;
+
+            _unlocked.Add(achievement.Name);
+
+            var nameTag = new KeyValuePair<string, object?>("achievement.name", achievement.Name);
+            Telemetry.AchievementsUnlocked.Add(1, nameTag);
+
+            cycleSpan?.AddEvent(new ActivityEvent("AchievementUnlocked",
+                tags: new ActivityTagsCollection { { "achievement.name", achievement.Name } }));
+
+            display.SetAchievement(achievement.Name);
+
+            logger.LogInformation("Achievement unlocked: {Name} — {Description}",
+                achievement.Name, achievement.Description);
+        }
+    }
+}

--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -7,10 +7,12 @@ public class GameDisplay
     private string? _currentEvent;
     private string? _currentWarning;
     private string? _lastRepairMessage;
+    private string? _currentAchievement;
 
     public void SetEvent(string? message) => _currentEvent = message;
     public void SetWarning(string? message) => _currentWarning = message;
     public void SetRepairMessage(string? message) => _lastRepairMessage = message;
+    public void SetAchievement(string? message) => _currentAchievement = message;
 
     public static void RenderStartScreen()
     {
@@ -31,9 +33,7 @@ public class GameDisplay
     public void Render(Station station)
     {
         Console.Clear();
-        var uptime = DateTime.UtcNow - station.StartTime;
         var hullStr = $"{station.HullIntegrity:F0}%";
-        var uptimeStr = $"{(int)uptime.TotalMinutes}m {uptime.Seconds}s";
 
         Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("╔══════════════════════════════════════════════════╗");
@@ -79,6 +79,12 @@ public class GameDisplay
             WritePaddedLine($"  \u2604 {_currentEvent}");
             hasMessage = true;
         }
+        if (_currentAchievement != null)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            WritePaddedLine($"  \u2605 {_currentAchievement}");
+            hasMessage = true;
+        }
         if (_lastRepairMessage != null)
         {
             Console.ForegroundColor = ConsoleColor.Green;
@@ -95,7 +101,7 @@ public class GameDisplay
         Console.WriteLine("╠══════════════════════════════════════════════════╣");
         WritePaddedLine("  [1-4] Select   [R] Repair   [E] Emergency Pwr   ");
         WritePaddedLine($"  [Q] Quit   Emerg Pwr: {station.EmergencyPowerRemaining,-2} |  Repairs: {station.RepairsRemainingThisCycle,-2} left");
-        WritePaddedLine($"  Cycle: {station.CycleCount,-9}|  Uptime: {uptimeStr,-21}");
+        WritePaddedLine($"  Cycle: {station.CycleCount,-9}|  Score: {station.Score,-22}");
         Console.WriteLine("╚══════════════════════════════════════════════════╝");
         Console.ResetColor();
     }

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -7,6 +7,7 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using SpaceStationMonitor;
+using SpaceStationMonitor.Achievements;
 using SpaceStationMonitor.BugStrategies;
 
 // ── Splash gate ─────────────────────────────────────────────────────────────
@@ -75,6 +76,7 @@ var repairSystem = new RepairSystem(strategy);
 var eventEngine = new EventEngine();
 var cascadeEngine = new CascadeEngine(strategy);
 var display = new GameDisplay();
+var achievementSystem = new AchievementSystem();
 int selectedSubsystem = 0;
 
 // ── OTel setup ──────────────────────────────────────────────────────────────
@@ -176,6 +178,7 @@ try
         }
 
         display.SetRepairMessage(null);
+        display.SetAchievement(null);
 
         if (shutdownCts.IsCancellationRequested) break;
 
@@ -253,6 +256,9 @@ try
 
             eventEngine.ApplyEvent(stationEvent, station);
 
+            if (stationEvent.Type == StationEventType.SolarFlare)
+                station.RecordSolarFlare();
+
             Telemetry.EventsTotal.Add(1,
                 new KeyValuePair<string, object?>("event.type", stationEvent.Type.ToString()),
                 new KeyValuePair<string, object?>("event.severity", stationEvent.Severity.ToString()));
@@ -269,6 +275,8 @@ try
         }
 
         Telemetry.CyclesTotal.Add(strategy.CycleCounterIncrement());
+        station.EndCycle();
+        achievementSystem.CheckAndFire(station, cycleActivity, logger, display);
         cycleActivity?.SetTag("hull.integrity", Math.Round(station.HullIntegrity, 1));
 
         logger.LogInformation("Station cycle {Cycle} complete — hull integrity {Hull:F1}%",
@@ -301,6 +309,7 @@ else
 }
 Console.WriteLine($"  Cycles survived: {station.CycleCount}");
 Console.WriteLine($"  Final hull integrity: {station.HullIntegrity:F1}%");
+Console.WriteLine($"  Achievements: {achievementSystem.UnlockedNames.Count} — {string.Join(", ", achievementSystem.UnlockedNames)}");
 Console.ResetColor();
 
 logger.LogInformation("Game over — Cycles: {Cycles}, Hull: {Hull:F1}%",
@@ -348,6 +357,7 @@ void HandleRepair(Station station, RepairSystem repairSystem, int subsystemIndex
             : 0;
         Telemetry.RepairEffectiveness.Record(effectiveness,
             new KeyValuePair<string, object?>("subsystem.name", result.SubsystemName));
+        station.RecordRepair(effectiveness);
 
         if (!result.IsHealthy)
         {

--- a/src/SpaceStationMonitor/Station.cs
+++ b/src/SpaceStationMonitor/Station.cs
@@ -1,3 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SpaceStationMonitor.Tests")]
+
 namespace SpaceStationMonitor;
 
 public class Subsystem
@@ -44,6 +48,18 @@ public class Station
     public int CycleCount { get; private set; }
     public DateTime StartTime { get; } = DateTime.UtcNow;
 
+    public int RepairsTotalThisSession { get; private set; }
+    public Queue<double> RecentRepairEffectiveness { get; } = new();
+    public int IronHullStreak { get; private set; }
+    public bool SolarFlareThisCycle { get; private set; }
+    public bool MinSubsystemStayedAbove30 { get; private set; }
+    public int CyclesAfterEmergencyExhausted { get; private set; }
+
+    // CascadeCount is owned by D2 (Chohfi) — incremented from Program.cs cascade block.
+    public int CascadeCount { get; internal set; }
+
+    public int Score => 10 * CycleCount + 5 * RepairsTotalThisSession - 50 * CascadeCount;
+
     public double HullIntegrity =>
         Subsystems.Average(s => Math.Max(0, s.Health));
 
@@ -51,6 +67,12 @@ public class Station
     {
         CycleCount++;
         RepairsRemainingThisCycle = _repairsPerCycle;
+        SolarFlareThisCycle = false;
+
+        if (EmergencyPowerRemaining == 0)
+            CyclesAfterEmergencyExhausted++;
+        else
+            CyclesAfterEmergencyExhausted = 0;
 
         // Pre-bug: flat 1.0 (fun, winnable baseline).
         // Post-bug: step to 1.5x on activation, then +0.04 per cycle (compounding collapse).
@@ -63,6 +85,24 @@ public class Station
         {
             _difficultyMultiplier = 1.0;
         }
+    }
+
+    public void RecordRepair(double effectivenessPercent)
+    {
+        RepairsTotalThisSession++;
+        RecentRepairEffectiveness.Enqueue(effectivenessPercent);
+        while (RecentRepairEffectiveness.Count > 20)
+            RecentRepairEffectiveness.Dequeue();
+    }
+
+    public void RecordSolarFlare() => SolarFlareThisCycle = true;
+
+    public void EndCycle()
+    {
+        if (HullIntegrity >= 80) IronHullStreak++;
+        else IronHullStreak = 0;
+
+        MinSubsystemStayedAbove30 = Subsystems.All(s => s.Health >= 30);
     }
 
     public bool TryConsumeRepair()

--- a/src/SpaceStationMonitor/Station.cs
+++ b/src/SpaceStationMonitor/Station.cs
@@ -55,7 +55,6 @@ public class Station
     public bool MinSubsystemStayedAbove30 { get; private set; }
     public int CyclesAfterEmergencyExhausted { get; private set; }
 
-    // CascadeCount is owned by D2 (Chohfi) — incremented from Program.cs cascade block.
     public int CascadeCount { get; internal set; }
 
     public int Score => 10 * CycleCount + 5 * RepairsTotalThisSession - 50 * CascadeCount;

--- a/src/SpaceStationMonitor/Telemetry.cs
+++ b/src/SpaceStationMonitor/Telemetry.cs
@@ -37,6 +37,11 @@ public static class Telemetry
         Meter.CreateHistogram<double>("station.repair.effectiveness", "percent",
             description: "Ratio of repair applied vs requested (100 = healthy)");
 
+    // UpDownCounter
+    public static readonly UpDownCounter<long> AchievementsUnlocked =
+        Meter.CreateUpDownCounter<long>("station.achievements.unlocked",
+            description: "Net achievements unlocked this session");
+
     // Note: ObservableGauges (station.subsystem.health, station.hull.integrity)
     // are registered in Program.cs because they need a reference to the Station instance.
 }

--- a/tests/SpaceStationMonitor.Tests/AchievementSystemTests.cs
+++ b/tests/SpaceStationMonitor.Tests/AchievementSystemTests.cs
@@ -1,0 +1,203 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using SpaceStationMonitor.Achievements;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class AchievementSystemTests
+{
+    private static readonly ILogger Logger = NullLogger.Instance;
+
+    private static (AchievementSystem sys, Station station, GameDisplay display) NewSystem()
+        => (new AchievementSystem(), new Station(), new GameDisplay());
+
+    [Fact]
+    public void FirstRepair_FiresAfterFirstRepair()
+    {
+        var (sys, station, display) = NewSystem();
+        station.RecordRepair(50.0);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("FirstRepair", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void Centurion_FiresAt100Cycles()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 100; i++) station.StartNewCycle(isBugActive: false);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("Centurion", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void Centurion_DoesNotFireBelow100()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 99; i++) station.StartNewCycle(isBugActive: false);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.DoesNotContain("Centurion", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void CascadeVeteran_FiresAt5Cascades()
+    {
+        var (sys, station, display) = NewSystem();
+        station.CascadeCount = 5;
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("CascadeVeteran", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void Surgeon_FiresWhenLast20Average90()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 20; i++) station.RecordRepair(90.0);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("Surgeon", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void Surgeon_DoesNotFireBelow90Mean()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 20; i++) station.RecordRepair(80.0);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.DoesNotContain("Surgeon", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void Surgeon_DoesNotFireWithFewerThan20Samples()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 19; i++) station.RecordRepair(95.0);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.DoesNotContain("Surgeon", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void EmptyTank_FiresAfter10CyclesWithExhaustedEmergencyPower()
+    {
+        var (sys, station, display) = NewSystem();
+        Assert.True(station.UseEmergencyPower());
+        Assert.True(station.UseEmergencyPower());
+        Assert.True(station.UseEmergencyPower());
+        Assert.Equal(0, station.EmergencyPowerRemaining);
+
+        for (int i = 0; i < 10; i++) station.StartNewCycle(isBugActive: false);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("EmptyTank", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void EmptyTank_DoesNotFireWhenEmergencyPowerStillAvailable()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 50; i++) station.StartNewCycle(isBugActive: false);
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.DoesNotContain("EmptyTank", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void IronHull_FiresAfter50ConsecutiveHealthyCycles()
+    {
+        var (sys, station, display) = NewSystem();
+        for (int i = 0; i < 50; i++)
+        {
+            station.StartNewCycle(isBugActive: false);
+            station.EndCycle();
+        }
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("IronHull", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void IronHull_StreakResetsWhenHullDropsBelow80()
+    {
+        var (_, station, _) = NewSystem();
+        for (int i = 0; i < 30; i++)
+        {
+            station.StartNewCycle(isBugActive: false);
+            station.EndCycle();
+        }
+        Assert.Equal(30, station.IronHullStreak);
+
+        // Tank one subsystem so hull = 75 (below 80).
+        station.Subsystems[0].Health = 0;
+        station.StartNewCycle(isBugActive: false);
+        station.EndCycle();
+
+        Assert.Equal(0, station.IronHullStreak);
+    }
+
+    [Fact]
+    public void SolarSurvivor_FiresWhenSolarFlareSurvivedWithoutCriticalDip()
+    {
+        var (sys, station, display) = NewSystem();
+        station.StartNewCycle(isBugActive: false);
+        station.RecordSolarFlare();
+        station.EndCycle();
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Contains("SolarSurvivor", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void SolarSurvivor_DoesNotFireWhenSubsystemDroppedBelow30()
+    {
+        var (sys, station, display) = NewSystem();
+        station.StartNewCycle(isBugActive: false);
+        station.RecordSolarFlare();
+        station.Subsystems[0].Health = 25;
+        station.EndCycle();
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.DoesNotContain("SolarSurvivor", sys.UnlockedNames);
+    }
+
+    [Fact]
+    public void Achievement_FiresOnlyOncePerSession()
+    {
+        var (sys, station, display) = NewSystem();
+        station.RecordRepair(50.0);
+
+        sys.CheckAndFire(station, null, Logger, display);
+        var firstCount = sys.UnlockedNames.Count;
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Equal(firstCount, sys.UnlockedNames.Count);
+    }
+
+    [Fact]
+    public void NoAchievementsFire_OnFreshStation()
+    {
+        var (sys, station, display) = NewSystem();
+
+        sys.CheckAndFire(station, null, Logger, display);
+
+        Assert.Empty(sys.UnlockedNames);
+    }
+}


### PR DESCRIPTION
## Summary

Implements §2.3 of the Sprint 002 task breakdown — the Score & Achievement system (Issue #35, P1, S-scope). Independent stream; ships in parallel with B2 and D2.

- Adds Station session-tracking fields (`Score` computed property, `RepairsTotalThisSession`, `RecentRepairEffectiveness`, `IronHullStreak`, `SolarFlareThisCycle`, `MinSubsystemStayedAbove30`, `CyclesAfterEmergencyExhausted`, `CascadeCount`) + `RecordRepair`, `RecordSolarFlare`, `EndCycle` methods. `Score` is the PM-ratified formula computed read-time. `CascadeCount` exposes `internal set` so D2 (Chohfi) can increment from his Program.cs cascade block.
- Adds `Achievement` record and `AchievementSystem` (`Achievements/`) with all 7 pinned predicates: `FirstRepair`, `Centurion`, `CascadeVeteran`, `Surgeon`, `EmptyTank`, `IronHull`, `SolarSurvivor`. `CheckAndFire` is once-per-session per name and emits the UpDownCounter, span event, display toast, and Info log per Research §B3 AC4.
- Adds `Telemetry.AchievementsUnlocked` (`UpDownCounter<long>`, `station.achievements.unlocked`).
- `GameDisplay`: `_currentAchievement` toast (cyan, ★ glyph) at priority 3 in the message stack per UI §2.4; footer row N+4 swaps uptime cell for `Score:` cell per UI §2.1.
- `Program.cs`: clears the toast at top of cycle alongside the repair-message clear; flips `SolarFlareThisCycle` from the event block when `stationEvent.Type == SolarFlare`; calls `station.EndCycle()` then `achievementSystem.CheckAndFire(...)` after `Telemetry.CyclesTotal.Add(...)`; records each successful repair's effectiveness into Station session history; game-over reveal prints `Achievements: <N> — <names>` sourced from `AchievementSystem.UnlockedNames` (telemetry-truth-only — counter is never read back).
- 15 new tests in `AchievementSystemTests.cs` cover every predicate's fire / no-fire condition, the once-per-session guarantee, and the `IronHull` streak reset.

## Coordination notes

- **B2 conflict on `GameDisplay.cs`** — Scott's B2 lands the multi-segment helper and the sampler badge on row 3. This PR only edits the message block (toast) and footer row N+4 (score). Per breakdown §3 Option A, this PR rebases on B2 once it merges. The toast and the score footer are single-color, so they don't need the multi-segment helper.
- **D2 dependency** — `Station.CascadeCount { get; internal set; }` is defined here. Chohfi's D2 PR will increment it from his Program.cs cascade block. No other code reads CascadeCount yet apart from `Score` and the `CascadeVeteran` predicate.
- **Game-over ordering** — Chohfi's `Cascade failures: N | Traces captured: M` line goes ABOVE the `Achievements:` line per breakdown §2.5; the rebase merge will splice his line in.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 75/75 green (60 prior + 15 new)
- [ ] Manual smoke against Aspire dashboard: trigger `FirstRepair` (one repair); confirm `station.achievements.unlocked` UpDown counter ticks +1 and the cycle span carries an `AchievementUnlocked` event with `achievement.name` tag
- [ ] Manual smoke: confirm score in footer ticks every cycle and that the toast clears on the next cycle
- [ ] QA verifies game-over reveal `Achievements: N — names` line is present and reads from `AchievementSystem.UnlockedNames` (not from the counter)

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)