### PR TITLE
Sprint 002 #33: HullThresholdSampler with hysteresis + HUD badge

### DIFF
--- a/docs/bug-catalog-debugging.md
+++ b/docs/bug-catalog-debugging.md
@@ -8,7 +8,7 @@ This cheat sheet is a walkthrough, not an answer key. For each bug it nudges you
 
 By default, one of the six strategies below is picked at random when the game starts. If you want to control it:
 
-- `BUG_STRATEGY=<name>` forces a specific strategy. Case-insensitive. Valid names: `LeakyRepair`, `LatencyInjection`, `SilentCounterCorruption`, `StickyCascadeMultiplier`, `WrongTargetDegradation`, `RetryStorm`. Unknown names exit with code 2 and print the valid list to stderr.
+- `BUG_STRATEGY=<name>` forces a specific strategy. Case-insensitive. Valid names: `LeakyRepair`, `LatencyInjection`, `SilentCounterCorruption`, `StickyCascadeMultiplier`, `WrongTargetDegradation`, `RetryStorm`, `SamplingBlindSpot`. Unknown names exit with code 2 and print the valid list to stderr.
 - `BUG_STRATEGY_SEED=<int>` seeds the RNG that picks both the target subsystem and the strategy. Same seed, same `(target, strategy)` pair. Only used when `BUG_STRATEGY` is unset.
 
 On startup the game logs `Bug strategy: <Name>, target: <Target>` so you know what was chosen. The mechanics of each strategy stay hidden, since figuring those out is the point.
@@ -95,3 +95,17 @@ Each section has the symptom you'll notice as a player, then a numbered walkthro
 4. Filter logs by "quota exhausted". How many entries show up inside a single cycle? Is one user click producing one entry, or many?
 
 *Teaches: sanity-checking counter rates against actual user actions. Ratio metrics. Spans record what the system attempted, not just what the user asked for, and that gap is where retry bugs live.*
+
+---
+
+## SamplingBlindSpot
+
+**Symptom:** the counter says N cascade failures but Traces show far fewer. The game-over screen even rubs your nose in it: `Cascade failures: 7  |  Traces captured: 1`.
+
+1. Open Metrics. Pull `station.cascade.failures`. Sum the rate over the session. Does the total line up with what the game-over screen reported?
+2. Switch to Traces, filter by `name=CascadeCheck`, count them over the same window. How does the trace count compare to the counter total?
+3. The mismatch is the bug. Counters and traces are independent pipelines — sampling decisions only touch traces. Where would you look to confirm the sampler is the cause?
+4. Open the `bug.strategy` resource attribute on any span you do still see. The strategy name is the giveaway, but what does the sampler config in `Program.cs` look like to make it land?
+5. Compare against `B2` — the hull-driven sampler should ramp up tracing on critical hull. Is it doing that, or is something pinning the rate low?
+
+*Teaches: head sampling makes its decision before the cascade tag exists, so it cannot bias toward errors. Counters and traces are independent — trace loss does not affect metric totals. This is the case for pairing head sampling with tail-based sampling and/or always-on error sampling in production.*

--- a/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
+++ b/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
@@ -10,6 +10,7 @@ public static class BugStrategyCatalog
         new StickyCascadeMultiplierStrategy(bugTarget),
         new WrongTargetDegradationStrategy(bugTarget),
         new RetryStormStrategy(bugTarget),
+        new SamplingBlindSpotStrategy(bugTarget),
     ];
 
     public static IBugStrategy? FindByName(IEnumerable<IBugStrategy> strategies, string name)

--- a/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
@@ -1,0 +1,14 @@
+namespace SpaceStationMonitor.BugStrategies;
+
+// All gameplay-side hooks (OnRepair, retries, cycle counter, cascade reset,
+// degradation redirect, repair delay) stay no-op. The visible effect comes
+// from a sidecar in Program.cs that swaps the sampler's OverrideSampler when
+// IsBugActive flips — see dev-design §0.5 (Path 2). Counters keep recording
+// at full fidelity; only spans drop, which is the teaching beat.
+public class SamplingBlindSpotStrategy : BugStrategyBase
+{
+    public SamplingBlindSpotStrategy(string bugTargetSubsystem, TimeSpan? activationDelay = null)
+        : base(bugTargetSubsystem, activationDelay) { }
+
+    public override string Name => "SamplingBlindSpot";
+}

--- a/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
@@ -1,3 +1,5 @@
+using OpenTelemetry.Trace;
+
 namespace SpaceStationMonitor.BugStrategies;
 
 // All gameplay-side hooks (OnRepair, retries, cycle counter, cascade reset,
@@ -7,6 +9,10 @@ namespace SpaceStationMonitor.BugStrategies;
 // at full fidelity; only spans drop, which is the teaching beat.
 public class SamplingBlindSpotStrategy : BugStrategyBase
 {
+    // Allocated once and reused — matches B2's pattern for HullThresholdSampler's
+    // ratio-based sampler. Per-cycle allocation would churn small objects in the hot path.
+    public static readonly Sampler HostileSampler = new TraceIdRatioBasedSampler(0.05);
+
     public SamplingBlindSpotStrategy(string bugTargetSubsystem, TimeSpan? activationDelay = null)
         : base(bugTargetSubsystem, activationDelay) { }
 

--- a/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
@@ -2,15 +2,16 @@ using OpenTelemetry.Trace;
 
 namespace SpaceStationMonitor.BugStrategies;
 
-// All gameplay-side hooks (OnRepair, retries, cycle counter, cascade reset,
-// degradation redirect, repair delay) stay no-op. The visible effect comes
-// from a sidecar in Program.cs that swaps the sampler's OverrideSampler when
-// IsBugActive flips — see dev-design §0.5 (Path 2). Counters keep recording
-// at full fidelity; only spans drop, which is the teaching beat.
+// IBugStrategy hooks (OnRepair, retries, cycle counter, cascade reset,
+// degradation redirect, repair delay) all stay no-op for this strategy.
+// The teaching-beat effect lives at the sampler boundary: while the bug is
+// active, the per-cycle override toggle redirects sampling decisions to
+// HostileSampler, dropping ~95% of spans while counters keep recording at
+// full fidelity. Activation policy is the standard BugStrategyBase delay.
 public class SamplingBlindSpotStrategy : BugStrategyBase
 {
-    // Allocated once and reused — matches B2's pattern for HullThresholdSampler's
-    // ratio-based sampler. Per-cycle allocation would churn small objects in the hot path.
+    // Reused across activations: the rate is fixed, so a fresh allocation per
+    // toggle would only churn small objects without changing behavior.
     public static readonly Sampler HostileSampler = new TraceIdRatioBasedSampler(0.05);
 
     public SamplingBlindSpotStrategy(string bugTargetSubsystem, TimeSpan? activationDelay = null)

--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -130,9 +130,12 @@ public class GameDisplay
         Console.WriteLine($"║{inner}{new string(' ', InnerWidth - inner.Length)}║");
     }
 
-    // Writes a single inner row composed of multiple colored segments. Caller is
-    // responsible for sizing segments so the sum matches InnerWidth — this method
-    // pads with spaces if shorter and truncates the last segment if longer.
+    /// <summary>
+    /// Writes a single inner row composed of multiple colored segments. Caller is
+    /// responsible for sizing segments so the sum matches <see cref="InnerWidth"/> —
+    /// this method pads with spaces if shorter and truncates the last segment if longer.
+    /// </summary>
+    /// <param name="segments">Ordered (text, foreground color) pairs rendered left-to-right.</param>
     private static void WritePaddedSegments(params (string text, ConsoleColor color)[] segments)
     {
         var prevColor = Console.ForegroundColor;

--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -1,3 +1,5 @@
+using SpaceStationMonitor.Sampling;
+
 namespace SpaceStationMonitor;
 
 public class GameDisplay
@@ -30,7 +32,7 @@ public class GameDisplay
         Console.ResetColor();
     }
 
-    public void Render(Station station)
+    public void Render(Station station, HullThresholdSampler? sampler = null)
     {
         ClearIfInteractive();
         var hullStr = $"{station.HullIntegrity:F0}%";
@@ -39,8 +41,24 @@ public class GameDisplay
         Console.WriteLine("╔══════════════════════════════════════════════════╗");
         WritePaddedLine("          SPACE STATION MONITOR v1.0              ");
 
-        Console.ForegroundColor = station.HullIntegrity < 30 ? ConsoleColor.Red : ConsoleColor.Cyan;
-        WritePaddedLine($"          Hull Integrity: {hullStr,-24}");
+        // Row 3 — hull + sampler badge. Column accounting (UI §1.3): 10 + 16 + 7 + 9 + 8 = 50.
+        var hullColor = station.HullIntegrity < 30 ? ConsoleColor.Red : ConsoleColor.Cyan;
+        if (sampler != null)
+        {
+            var stormy = sampler.CurrentRegime == SamplingRegime.Storm;
+            var badgeText = stormy ? "◉ rec" : "◌ idle";  // ◉ rec / ◌ idle
+            var badgeColor = stormy ? ConsoleColor.Red : ConsoleColor.DarkCyan;
+            WritePaddedSegments(
+                ("          Hull Integrity: ", ConsoleColor.Cyan),
+                ($"{hullStr,-7}", hullColor),
+                ("Sampler: ", ConsoleColor.Cyan),
+                ($"{badgeText,-8}", badgeColor));
+        }
+        else
+        {
+            Console.ForegroundColor = hullColor;
+            WritePaddedLine($"          Hull Integrity: {hullStr,-24}");
+        }
 
         Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("╠══════════════════════════════════════════════════╣");
@@ -110,6 +128,39 @@ public class GameDisplay
     {
         var inner = content.Length > InnerWidth ? content[..InnerWidth] : content;
         Console.WriteLine($"║{inner}{new string(' ', InnerWidth - inner.Length)}║");
+    }
+
+    // Writes a single inner row composed of multiple colored segments. Caller is
+    // responsible for sizing segments so the sum matches InnerWidth — this method
+    // pads with spaces if shorter and truncates the last segment if longer.
+    private static void WritePaddedSegments(params (string text, ConsoleColor color)[] segments)
+    {
+        var prevColor = Console.ForegroundColor;
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.Write("║");
+
+        int written = 0;
+        foreach (var (text, color) in segments)
+        {
+            var remaining = InnerWidth - written;
+            if (remaining <= 0) break;
+            var slice = text.Length > remaining ? text[..remaining] : text;
+            Console.ForegroundColor = color;
+            Console.Write(slice);
+            written += slice.Length;
+        }
+
+        if (written < InnerWidth)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.Write(new string(' ', InnerWidth - written));
+        }
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("║");
+
+        Console.ForegroundColor = prevColor;
     }
 
     // Console.Clear() throws IOException when stdout is redirected (xUnit test runner).

--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -41,12 +41,12 @@ public class GameDisplay
         Console.WriteLine("╔══════════════════════════════════════════════════╗");
         WritePaddedLine("          SPACE STATION MONITOR v1.0              ");
 
-        // Row 3 — hull + sampler badge. Column accounting (UI §1.3): 10 + 16 + 7 + 9 + 8 = 50.
+        // Row 3 column budget must total InnerWidth: 10 + 16 + 7 + 9 + 8 = 50.
         var hullColor = station.HullIntegrity < 30 ? ConsoleColor.Red : ConsoleColor.Cyan;
         if (sampler != null)
         {
             var stormy = sampler.CurrentRegime == SamplingRegime.Storm;
-            var badgeText = stormy ? "◉ rec" : "◌ idle";  // ◉ rec / ◌ idle
+            var badgeText = stormy ? "◉ rec" : "◌ idle";
             var badgeColor = stormy ? ConsoleColor.Red : ConsoleColor.DarkCyan;
             WritePaddedSegments(
                 ("          Hull Integrity: ", ConsoleColor.Cyan),
@@ -131,9 +131,9 @@ public class GameDisplay
     }
 
     /// <summary>
-    /// Writes a single inner row composed of multiple colored segments. Caller is
-    /// responsible for sizing segments so the sum matches <see cref="InnerWidth"/> —
-    /// this method pads with spaces if shorter and truncates the last segment if longer.
+    /// Writes a single inner row composed of multiple colored segments. Caller is responsible
+    /// for sizing segments so the sum matches <see cref="InnerWidth"/>; the method pads with
+    /// spaces when shorter and truncates the last segment when longer.
     /// </summary>
     /// <param name="segments">Ordered (text, foreground color) pairs rendered left-to-right.</param>
     private static void WritePaddedSegments(params (string text, ConsoleColor color)[] segments)

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Trace;
 using SpaceStationMonitor.Achievements;
 using SpaceStationMonitor.BugStrategies;
 using SpaceStationMonitor.Sampling;
@@ -98,11 +97,12 @@ public sealed class GameLoop
 
                 // D2 sidecar (dev-design §0.5, Path 2). Idempotent per-cycle —
                 // the IsBugActive flip drives the override on, deactivation drives it off.
+                // Reuses SamplingBlindSpotStrategy.HostileSampler — no per-cycle alloc.
                 if (_sampler is not null)
                 {
                     _sampler.OverrideSampler =
                         _repairSystem.Strategy is SamplingBlindSpotStrategy && isBugActive
-                            ? new TraceIdRatioBasedSampler(0.05)
+                            ? SamplingBlindSpotStrategy.HostileSampler
                             : null;
                 }
 

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Trace;
 using SpaceStationMonitor.Achievements;
 using SpaceStationMonitor.BugStrategies;
 using SpaceStationMonitor.Sampling;
@@ -95,6 +96,16 @@ public sealed class GameLoop
 
                 bool isBugActive = _repairSystem.IsBugActive;
 
+                // D2 sidecar (dev-design §0.5, Path 2). Idempotent per-cycle —
+                // the IsBugActive flip drives the override on, deactivation drives it off.
+                if (_sampler is not null)
+                {
+                    _sampler.OverrideSampler =
+                        _repairSystem.Strategy is SamplingBlindSpotStrategy && isBugActive
+                            ? new TraceIdRatioBasedSampler(0.05)
+                            : null;
+                }
+
                 using var cycleActivity = Telemetry.ActivitySource.StartActivity(
                     "StationCycle",
                     ActivityKind.Internal,
@@ -145,6 +156,12 @@ public sealed class GameLoop
                         new KeyValuePair<string, object?>("source.subsystem", cascade.SourceSubsystem),
                         new KeyValuePair<string, object?>("affected.subsystem",
                             string.Join(",", cascade.AffectedSubsystems)));
+
+                    _station.CascadeCount++;
+                    // IsAllDataRequested is the sampler decision, not a metric readback —
+                    // PM ratified this read for the SamplingBlindSpot reveal (dev-design §0.4).
+                    if (cascadeActivity != null && cascadeActivity.IsAllDataRequested)
+                        _station.CascadesTracedCount++;
 
                     _logger.LogError("Cascade failure: {Source} → {Affected}",
                         cascade.SourceSubsystem, string.Join(", ", cascade.AffectedSubsystems));

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using SpaceStationMonitor.Achievements;
 using SpaceStationMonitor.BugStrategies;
+using SpaceStationMonitor.Sampling;
 
 namespace SpaceStationMonitor;
 
@@ -27,6 +28,7 @@ public sealed class GameLoop
     private readonly AchievementSystem? _achievementSystem;
     private readonly Action? _onQuit;
     private readonly Func<char?>? _keyReader;
+    private readonly HullThresholdSampler? _sampler;
 
     private int _selectedSubsystem;
 
@@ -42,7 +44,8 @@ public sealed class GameLoop
         TestModeConfig testConfig,
         AchievementSystem? achievementSystem = null,
         Action? onQuit = null,
-        Func<char?>? keyReader = null)
+        Func<char?>? keyReader = null,
+        HullThresholdSampler? sampler = null)
     {
         _station = station;
         _repairSystem = repairSystem;
@@ -56,11 +59,12 @@ public sealed class GameLoop
         _achievementSystem = achievementSystem;
         _onQuit = onQuit;
         _keyReader = keyReader;
+        _sampler = sampler;
     }
 
     public async Task RunAsync(CancellationToken shutdownToken)
     {
-        _display.Render(_station);
+        _display.Render(_station, _sampler);
 
         try
         {
@@ -182,7 +186,7 @@ public sealed class GameLoop
                 _logger.LogInformation("Station cycle {Cycle} complete — hull integrity {Hull:F1}%",
                     _station.CycleCount, _station.HullIntegrity);
 
-                _display.Render(_station);
+                _display.Render(_station, _sampler);
 
                 if (_testConfig.MaxCycles is int max && _station.CycleCount >= max) break;
             }
@@ -224,10 +228,10 @@ public sealed class GameLoop
     {
         switch (key)
         {
-            case '1': _selectedSubsystem = 0; _display.Render(_station); break;
-            case '2': _selectedSubsystem = 1; _display.Render(_station); break;
-            case '3': _selectedSubsystem = 2; _display.Render(_station); break;
-            case '4': _selectedSubsystem = 3; _display.Render(_station); break;
+            case '1': _selectedSubsystem = 0; _display.Render(_station, _sampler); break;
+            case '2': _selectedSubsystem = 1; _display.Render(_station, _sampler); break;
+            case '3': _selectedSubsystem = 2; _display.Render(_station, _sampler); break;
+            case '4': _selectedSubsystem = 3; _display.Render(_station, _sampler); break;
 
             case 'R': HandleRepair(); break;
             case 'E': HandleEmergencyPower(); break;
@@ -279,7 +283,7 @@ public sealed class GameLoop
                 new KeyValuePair<string, object?>("subsystem.name", sub.Name));
             _logger.LogInformation("Repair denied on {Name}: quota exhausted this cycle", sub.Name);
             _display.SetRepairMessage("No repairs left this cycle — wait for next tick");
-            _display.Render(_station);
+            _display.Render(_station, _sampler);
             return;
         }
 
@@ -336,7 +340,7 @@ public sealed class GameLoop
 
         _display.SetRepairMessage(
             $"Repaired {sub.Name}: {currentHealth:F0}% → {expectedHealth:F0}%");
-        _display.Render(_station);
+        _display.Render(_station, _sampler);
     }
 
     private void HandleEmergencyPower()
@@ -352,6 +356,6 @@ public sealed class GameLoop
         {
             _display.SetRepairMessage("No emergency power remaining!");
         }
-        _display.Render(_station);
+        _display.Render(_station, _sampler);
     }
 }

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -8,6 +8,7 @@ using OpenTelemetry.Trace;
 using SpaceStationMonitor;
 using SpaceStationMonitor.Achievements;
 using SpaceStationMonitor.BugStrategies;
+using SpaceStationMonitor.Sampling;
 
 // ── Test-mode flags (parsed once at startup) ────────────────────────────────
 var testConfig = TestModeConfig.FromEnvironment(Environment.GetEnvironmentVariable);
@@ -82,6 +83,7 @@ var eventEngine = new EventEngine();
 var cascadeEngine = new CascadeEngine(strategy);
 var display = new GameDisplay();
 var achievementSystem = new AchievementSystem();
+var sampler = new HullThresholdSampler(() => station.HullIntegrity);
 
 // ── OTel setup ──────────────────────────────────────────────────────────────
 // bug.strategy goes on the resource so it's filterable across all signals
@@ -92,6 +94,7 @@ var resourceBuilder = ResourceBuilder.CreateDefault()
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .SetResourceBuilder(resourceBuilder)
+    .SetSampler(new ParentBasedSampler(sampler))
     .AddSource(Telemetry.ActivitySourceName)
     .AddOtlpExporter()
     .Build();
@@ -136,7 +139,8 @@ logger.LogInformation("Bug strategy: {Name}, target: {Target}",
 var gameLoop = new GameLoop(
     station, repairSystem, eventEngine, cascadeEngine, display, random, logger, strategy, testConfig,
     achievementSystem,
-    onQuit: () => shutdownCts.Cancel());
+    onQuit: () => shutdownCts.Cancel(),
+    sampler: sampler);
 await gameLoop.RunAsync(shutdownCts.Token);
 
 // ── Game over ───────────────────────────────────────────────────────────────

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -164,6 +164,7 @@ else
 }
 Console.WriteLine($"  Cycles survived: {station.CycleCount}");
 Console.WriteLine($"  Final hull integrity: {station.HullIntegrity:F1}%");
+Console.WriteLine($"  Cascade failures: {station.CascadeCount,-3}  |   Traces captured: {station.CascadesTracedCount,-3}");
 Console.WriteLine($"  Achievements: {achievementSystem.UnlockedNames.Count} — {string.Join(", ", achievementSystem.UnlockedNames)}");
 Console.ResetColor();
 

--- a/src/SpaceStationMonitor/Sampling/HullThresholdSampler.cs
+++ b/src/SpaceStationMonitor/Sampling/HullThresholdSampler.cs
@@ -12,7 +12,7 @@ public enum SamplingRegime
 /// Hull-driven sampler with hysteresis.
 ///   Storm  (RecordAndSample): hull ≤ 70.0
 ///   Calm   (TraceIdRatioBased(0.10)): hull > 75.0
-///   Dead-band (70 &lt; hull ≤ 75): keep current regime — avoids per-cycle flicker.
+///   Dead-band (70 &lt; hull ≤ 75): keep current regime to avoid per-cycle flicker.
 /// </summary>
 public sealed class HullThresholdSampler : Sampler
 {
@@ -26,7 +26,7 @@ public sealed class HullThresholdSampler : Sampler
     public HullThresholdSampler(Func<double> hullProvider)
     {
         _hullProvider = hullProvider;
-        // Constructed once and reused — never re-allocated per ShouldSample call.
+        // Constructed once and reused, never re-allocated per ShouldSample call.
         _ratioBased = new TraceIdRatioBasedSampler(0.10);
         Description = "HullThresholdSampler{calm=ratio(0.10),storm=record,hyst=70/75}";
 
@@ -38,8 +38,7 @@ public sealed class HullThresholdSampler : Sampler
     }
 
     /// <summary>
-    /// When non-null, ShouldSample delegates to this sampler and ignores hull state.
-    /// Set by D2 (SamplingBlindSpot strategy) to pin a hostile fixed-rate sampler.
+    /// Set to a non-null sampler to override hull-driven behavior; null restores hull-threshold logic.
     /// </summary>
     public Sampler? OverrideSampler { get; set; }
 

--- a/src/SpaceStationMonitor/Sampling/HullThresholdSampler.cs
+++ b/src/SpaceStationMonitor/Sampling/HullThresholdSampler.cs
@@ -1,0 +1,79 @@
+using OpenTelemetry.Trace;
+
+namespace SpaceStationMonitor.Sampling;
+
+public enum SamplingRegime
+{
+    Calm,
+    Storm,
+}
+
+/// <summary>
+/// Hull-driven sampler with hysteresis.
+///   Storm  (RecordAndSample): hull ≤ 70.0
+///   Calm   (TraceIdRatioBased(0.10)): hull > 75.0
+///   Dead-band (70 &lt; hull ≤ 75): keep current regime — avoids per-cycle flicker.
+/// </summary>
+public sealed class HullThresholdSampler : Sampler
+{
+    public const double StormThreshold = 70.0;
+    public const double CalmThreshold = 75.0;
+
+    private readonly Func<double> _hullProvider;
+    private readonly Sampler _ratioBased;
+    private SamplingRegime _currentRegime;
+
+    public HullThresholdSampler(Func<double> hullProvider)
+    {
+        _hullProvider = hullProvider;
+        // Constructed once and reused — never re-allocated per ShouldSample call.
+        _ratioBased = new TraceIdRatioBasedSampler(0.10);
+        Description = "HullThresholdSampler{calm=ratio(0.10),storm=record,hyst=70/75}";
+
+        // Seed initial regime from the starting hull so a freshly-built sampler
+        // matches the visible state (e.g., dropped into a fight already at hull=60).
+        _currentRegime = hullProvider() <= StormThreshold
+            ? SamplingRegime.Storm
+            : SamplingRegime.Calm;
+    }
+
+    /// <summary>
+    /// When non-null, ShouldSample delegates to this sampler and ignores hull state.
+    /// Set by D2 (SamplingBlindSpot strategy) to pin a hostile fixed-rate sampler.
+    /// </summary>
+    public Sampler? OverrideSampler { get; set; }
+
+    public SamplingRegime CurrentRegime => _currentRegime;
+
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    {
+        if (OverrideSampler is { } overrideSampler)
+            return overrideSampler.ShouldSample(in samplingParameters);
+
+        UpdateRegime();
+
+        return _currentRegime == SamplingRegime.Storm
+            ? new SamplingResult(SamplingDecision.RecordAndSample)
+            : _ratioBased.ShouldSample(in samplingParameters);
+    }
+
+    private void UpdateRegime()
+    {
+        double hull = _hullProvider();
+
+        // Hysteresis: only flip when crossing the OPPOSITE threshold for the current regime.
+        // Calm → Storm: hull crosses down through 70.
+        // Storm → Calm: hull crosses up through 75.
+        // Dead-band (70 < hull ≤ 75): no transition.
+        if (_currentRegime == SamplingRegime.Calm)
+        {
+            if (hull <= StormThreshold)
+                _currentRegime = SamplingRegime.Storm;
+        }
+        else
+        {
+            if (hull > CalmThreshold)
+                _currentRegime = SamplingRegime.Calm;
+        }
+    }
+}

--- a/src/SpaceStationMonitor/Sampling/HullThresholdSampler.cs
+++ b/src/SpaceStationMonitor/Sampling/HullThresholdSampler.cs
@@ -42,7 +42,15 @@ public sealed class HullThresholdSampler : Sampler
     /// </summary>
     public Sampler? OverrideSampler { get; set; }
 
-    public SamplingRegime CurrentRegime => _currentRegime;
+    /// <summary>
+    /// While <see cref="OverrideSampler"/> is non-null, regime reads as Calm
+    /// regardless of hull — the badge stays Calm even as hull collapses, which is
+    /// the visible-but-easy-to-miss D2 SamplingBlindSpot teaching beat. The
+    /// underlying <c>_currentRegime</c> stays frozen so transitions resume cleanly
+    /// from where they were when the override clears.
+    /// </summary>
+    public SamplingRegime CurrentRegime =>
+        OverrideSampler is not null ? SamplingRegime.Calm : _currentRegime;
 
     public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
     {

--- a/src/SpaceStationMonitor/Station.cs
+++ b/src/SpaceStationMonitor/Station.cs
@@ -56,6 +56,7 @@ public class Station
     public int CyclesAfterEmergencyExhausted { get; private set; }
 
     public int CascadeCount { get; internal set; }
+    public int CascadesTracedCount { get; internal set; }
 
     public int Score => 10 * CycleCount + 5 * RepairsTotalThisSession - 50 * CascadeCount;
 

--- a/tests/SpaceStationMonitor.Tests/HullThresholdSamplerTests.cs
+++ b/tests/SpaceStationMonitor.Tests/HullThresholdSamplerTests.cs
@@ -131,6 +131,33 @@ public class HullThresholdSamplerTests
             sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
     }
 
+    // RISK-1: while OverrideSampler is set, the badge must read Calm regardless
+    // of hull — that's the visible-but-easy-to-miss D2 SamplingBlindSpot teaching
+    // beat (counters say cascades happened; badge says Calm; player digs in).
+    // The underlying _currentRegime stays frozen; clearing the override resumes
+    // hull-driven transitions cleanly.
+    [Fact]
+    public void CurrentRegime_ForcesCalm_WhenOverrideSamplerSet()
+    {
+        double hull = 60.0; // Storm baseline.
+        var sampler = new HullThresholdSampler(() => hull);
+        Assert.Equal(SamplingRegime.Storm, sampler.CurrentRegime);
+
+        // Phase 1: hull=60 + override set → Calm.
+        sampler.OverrideSampler = new TraceIdRatioBasedSampler(0.05);
+        Assert.Equal(SamplingRegime.Calm, sampler.CurrentRegime);
+
+        // Phase 2: hull=90 + override still set → Calm.
+        hull = 90.0;
+        Assert.Equal(SamplingRegime.Calm, sampler.CurrentRegime);
+
+        // Phase 3: clear override + hull=90 → Calm via hull path.
+        // Drive ShouldSample once so UpdateRegime() catches up to the new hull.
+        sampler.OverrideSampler = null;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+        Assert.Equal(SamplingRegime.Calm, sampler.CurrentRegime);
+    }
+
     private static SamplingParameters MakeParams(ActivityTraceId traceId)
         => new SamplingParameters(
             parentContext: default,

--- a/tests/SpaceStationMonitor.Tests/HullThresholdSamplerTests.cs
+++ b/tests/SpaceStationMonitor.Tests/HullThresholdSamplerTests.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using SpaceStationMonitor.Sampling;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class HullThresholdSamplerTests
+{
+    [Fact]
+    public void ShouldSample_AtFullHealth_ReturnsRatioBased()
+    {
+        var sampler = new HullThresholdSampler(() => 100.0);
+        var reference = new TraceIdRatioBasedSampler(0.10);
+
+        // Find a TraceId the reference 10% sampler drops; assert ours drops the same one.
+        ActivityTraceId droppedId = default;
+        bool found = false;
+        for (int i = 0; i < 200; i++)
+        {
+            var candidate = ActivityTraceId.CreateRandom();
+            if (reference.ShouldSample(MakeParams(candidate)).Decision == SamplingDecision.Drop)
+            {
+                droppedId = candidate;
+                found = true;
+                break;
+            }
+        }
+        Assert.True(found, "Could not find a dropped TraceId in 200 tries");
+
+        var actual = sampler.ShouldSample(MakeParams(droppedId));
+
+        Assert.Equal(SamplingDecision.Drop, actual.Decision);
+        Assert.Equal(SamplingRegime.Calm, sampler.CurrentRegime);
+    }
+
+    [Fact]
+    public void ShouldSample_AtStormThreshold_ReturnsRecord()
+    {
+        var sampler = new HullThresholdSampler(() => 70.0);
+
+        var result = sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+
+        Assert.Equal(SamplingDecision.RecordAndSample, result.Decision);
+        Assert.Equal(SamplingRegime.Storm, sampler.CurrentRegime);
+    }
+
+    [Fact]
+    public void ShouldSample_BelowThreshold_ReturnsRecord()
+    {
+        var sampler = new HullThresholdSampler(() => 30.0);
+
+        // Every TraceId should RecordAndSample at this hull, regardless of TraceId hash.
+        for (int i = 0; i < 20; i++)
+        {
+            var result = sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+            Assert.Equal(SamplingDecision.RecordAndSample, result.Decision);
+        }
+    }
+
+    [Fact]
+    public void ParentBased_ChildInheritsParentDecision()
+    {
+        // Hull at 30% means HullThresholdSampler would normally RecordAndSample.
+        // ParentBased wraps it and respects the parent's TraceFlags.
+        var sampler = new HullThresholdSampler(() => 30.0);
+        var parentBased = new ParentBasedSampler(sampler);
+
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var droppedParent = new ActivityContext(traceId, spanId, ActivityTraceFlags.None, isRemote: false);
+
+        var p = new SamplingParameters(droppedParent, traceId, "child", ActivityKind.Internal, null, null);
+        var result = parentBased.ShouldSample(p);
+
+        // Parent didn't record → child shouldn't record either.
+        Assert.NotEqual(SamplingDecision.RecordAndSample, result.Decision);
+    }
+
+    [Fact]
+    public void Hysteresis_DoesNotFlipUntilUpperBound()
+    {
+        double hull = 60.0;
+        var sampler = new HullThresholdSampler(() => hull);
+
+        // Start at hull = 60: ≤ 70 → Storm
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+        Assert.Equal(SamplingRegime.Storm, sampler.CurrentRegime);
+
+        // Raise to 73 (dead-band 70 < hull ≤ 75): stays Storm
+        hull = 73.0;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+        Assert.Equal(SamplingRegime.Storm, sampler.CurrentRegime);
+
+        // Raise to 76 (above 75): flips to Calm
+        hull = 76.0;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+        Assert.Equal(SamplingRegime.Calm, sampler.CurrentRegime);
+
+        // Drop to 71 (dead-band): stays Calm
+        hull = 71.0;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+        Assert.Equal(SamplingRegime.Calm, sampler.CurrentRegime);
+
+        // Drop to 69 (below 70): flips to Storm
+        hull = 69.0;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+        Assert.Equal(SamplingRegime.Storm, sampler.CurrentRegime);
+    }
+
+    [Fact]
+    public void OverrideSampler_TakesPriorityOverHull()
+    {
+        var sampler = new HullThresholdSampler(() => 30.0);
+
+        // Sanity: without override at hull=30, decisions are RecordAndSample.
+        Assert.Equal(SamplingDecision.RecordAndSample,
+            sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
+
+        // Override to a 0% sampler — drops everything regardless of hull.
+        sampler.OverrideSampler = new TraceIdRatioBasedSampler(0.0);
+        for (int i = 0; i < 10; i++)
+        {
+            var r = sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+            Assert.Equal(SamplingDecision.Drop, r.Decision);
+        }
+
+        // Clearing override restores hull-driven behavior.
+        sampler.OverrideSampler = null;
+        Assert.Equal(SamplingDecision.RecordAndSample,
+            sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
+    }
+
+    private static SamplingParameters MakeParams(ActivityTraceId traceId)
+        => new SamplingParameters(
+            parentContext: default,
+            traceId: traceId,
+            name: "test",
+            kind: ActivityKind.Internal,
+            tags: null,
+            links: null);
+}

--- a/tests/SpaceStationMonitor.Tests/SamplingBlindSpotStrategyTests.cs
+++ b/tests/SpaceStationMonitor.Tests/SamplingBlindSpotStrategyTests.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using SpaceStationMonitor;
+using SpaceStationMonitor.BugStrategies;
+using SpaceStationMonitor.Sampling;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class SamplingBlindSpotStrategyTests
+{
+    private const string Target = "Oxygen";
+
+    [Fact]
+    public void Strategy_IsRegistered_InCatalog()
+    {
+        var strategies = BugStrategyCatalog.All(Target);
+
+        var found = BugStrategyCatalog.FindByName(strategies, "SamplingBlindSpot");
+
+        Assert.NotNull(found);
+        Assert.IsType<SamplingBlindSpotStrategy>(found);
+    }
+
+    [Fact]
+    public void OnRepair_IsNoOp_ReturnsRequestedUnchanged()
+    {
+        // Effect lives in the sidecar (Program.cs), not in the IBugStrategy hooks.
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0) { Health = 50 };
+        int retryCount = 0;
+
+        var applied = strategy.OnRepair(sub, 25, ref retryCount);
+
+        Assert.Equal(25, applied);
+        Assert.Equal(0, retryCount);
+    }
+
+    [Fact]
+    public void ShouldRetryAfterFailure_AlwaysFalse()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0);
+
+        Assert.False(strategy.ShouldRetryAfterFailure(sub, 0));
+        Assert.False(strategy.ShouldRetryAfterFailure(sub, 5));
+    }
+
+    [Fact]
+    public void CycleCounterIncrement_AlwaysOne()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+
+        Assert.Equal(1, strategy.CycleCounterIncrement());
+    }
+
+    [Fact]
+    public void RedirectDegradationTarget_DoesNotRedirect()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0);
+        var all = new[] { sub, new Subsystem("Power", 1.0) };
+
+        var redirected = strategy.RedirectDegradationTarget(sub, all);
+
+        Assert.Same(sub, redirected);
+    }
+
+    [Fact]
+    public void RepairDelay_IsNull()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0);
+
+        Assert.Null(strategy.RepairDelay(sub));
+    }
+
+    [Fact]
+    public void IsBugActive_RespectsActivationDelay()
+    {
+        var notYet = new SamplingBlindSpotStrategy(Target, TimeSpan.FromMinutes(1));
+        var alreadyActive = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        // BugStrategyBase compares DateTime.UtcNow to its captured _startTime,
+        // so a 1-tick delay is enough to flip the predicate by the time we read it.
+        Thread.Sleep(2);
+
+        Assert.False(notYet.IsBugActive);
+        Assert.True(alreadyActive.IsBugActive);
+    }
+
+    // AC5 — sampler-coupled tests: the strategy's effect is observed at the
+    // HullThresholdSampler.OverrideSampler boundary, not on the strategy itself.
+    // The sidecar in GameLoop.cs assigns/clears OverrideSampler per cycle; here
+    // we drive the same toggle directly so the test is independent of the loop.
+
+    [Fact]
+    public void StrategyInactive_SamplerBehavesPerB2Spec()
+    {
+        // Mirrors B2 AC2 — Storm at hull ≤ 70 returns RecordAndSample;
+        // Calm at hull > 75 returns the 10% ratio sampler decision.
+        var hull = 30.0;
+        var sampler = new HullThresholdSampler(() => hull);
+        // sampler.OverrideSampler stays null — strategy effect not active.
+
+        Assert.Equal(SamplingDecision.RecordAndSample,
+            sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
+
+        hull = 100.0;
+        // Lift hull above the calm threshold then drive the sampler past one
+        // call so the regime transition catches up before we read.
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+
+        // At hull=100 the underlying ratio sampler dominates. Just confirm
+        // that ShouldSample respects the override-null path (not pinned at 5%).
+        // We don't probabilistically assert the 10% rate here — that's B2's plate.
+        int sampled = 0;
+        var rng = new Random(7);
+        for (int i = 0; i < 100; i++)
+        {
+            var traceId = MakeTraceId(rng);
+            if (sampler.ShouldSample(MakeParams(traceId)).Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+        // 10% binomial → mean 10, σ ≈ 3. <25 is comfortably outside the 5% pin.
+        Assert.True(sampled < 25,
+            $"inactive override should fall through to ~10% ratio; got {sampled}/100");
+    }
+
+    [Fact]
+    public void StrategyActive_RoutesEverythingThroughFivePercent_RegardlessOfHull()
+    {
+        var hull = 30.0; // Storm regime — would normally RecordAndSample.
+        var sampler = new HullThresholdSampler(() => hull);
+
+        // Activate D2's sidecar effect.
+        sampler.OverrideSampler = new TraceIdRatioBasedSampler(0.05);
+
+        int sampled = 0;
+        var rng = new Random(11);
+        for (int i = 0; i < 200; i++)
+        {
+            var traceId = MakeTraceId(rng);
+            if (sampler.ShouldSample(MakeParams(traceId)).Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+
+        // 5% × 200 → mean 10. p(>=25 sampled) ≪ 0.001. The hull=30 Storm
+        // path would have given 200/200 if the override hadn't intercepted.
+        Assert.True(sampled < 25,
+            $"active override should pin to ~5% regardless of Storm hull; got {sampled}/200");
+    }
+
+    [Fact]
+    public void Activation_IsReversible_WhenOverrideClearsHullPathReturns()
+    {
+        var hull = 30.0;
+        var sampler = new HullThresholdSampler(() => hull);
+
+        // Activate.
+        sampler.OverrideSampler = new TraceIdRatioBasedSampler(0.05);
+
+        // Deactivate — sidecar nulls it out when the strategy stops being active.
+        sampler.OverrideSampler = null;
+
+        // hull=30 → Storm → RecordAndSample once again.
+        Assert.Equal(SamplingDecision.RecordAndSample,
+            sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
+
+        // And lift hull above the calm threshold; now it falls back to the
+        // ratio sampler. Driver call to settle the regime transition.
+        hull = 100.0;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+
+        int sampled = 0;
+        var rng = new Random(23);
+        for (int i = 0; i < 100; i++)
+        {
+            var traceId = MakeTraceId(rng);
+            if (sampler.ShouldSample(MakeParams(traceId)).Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+        // After deactivation, calm hull → ~10% rate, not the 5% pin.
+        Assert.True(sampled < 25,
+            $"deactivated sampler should follow B2 hull behavior; got {sampled}/100");
+    }
+
+    private static ActivityTraceId MakeTraceId(Random rng)
+    {
+        var bytes = new byte[16];
+        rng.NextBytes(bytes);
+        return ActivityTraceId.CreateFromBytes(bytes);
+    }
+
+    private static SamplingParameters MakeParams(ActivityTraceId traceId) =>
+        new(parentContext: default,
+            traceId: traceId,
+            name: "CascadeCheck",
+            kind: ActivityKind.Internal);
+
+    // AC6 — statistical: 100 cascade events with the strategy active sample <15.
+    // We exercise TraceIdRatioBasedSampler(0.05) directly because the sidecar
+    // (Program.cs) hands that exact sampler to HullThresholdSampler.OverrideSampler
+    // when SamplingBlindSpot activates. p(>=15 sampled at p=0.05) is well under
+    // 0.001 — false-positive rate is negligible. Seeded RNG keeps the test
+    // deterministic across runs.
+    [Fact]
+    public void Sampling_AtFivePercent_DropsCascadeTraces()
+    {
+        var sampler = new TraceIdRatioBasedSampler(0.05);
+        var rng = new Random(42);
+        int sampled = 0;
+
+        for (int i = 0; i < 100; i++)
+        {
+            var traceIdBytes = new byte[16];
+            rng.NextBytes(traceIdBytes);
+            var traceId = ActivityTraceId.CreateFromBytes(traceIdBytes);
+
+            var parameters = new SamplingParameters(
+                parentContext: default,
+                traceId: traceId,
+                name: "CascadeCheck",
+                kind: ActivityKind.Internal);
+
+            var result = sampler.ShouldSample(in parameters);
+            if (result.Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+
+        Assert.True(sampled < 15,
+            $"expected <15 of 100 cascade events to be sampled at 5%, got {sampled}");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Sampling/HullThresholdSampler.cs` — a `Sampler` subclass driven by `Station.HullIntegrity` with the PM-amended hysteresis: Storm ≤ 70, Calm > 75, dead-band 70 < hull ≤ 75 keeps the current regime.
- 10% `TraceIdRatioBasedSampler` instance is built once in the ctor and reused; never re-allocated per `ShouldSample`.
- Public `Sampler? OverrideSampler { get; set; }` so D2's `SamplingBlindSpotStrategy` can pin a hostile fixed-rate sampler regardless of hull state.
- Public `SamplingRegime CurrentRegime { get; }` (`Calm` / `Storm`) so the HUD reads the regime instead of duplicating threshold math.
- `Program.cs` calls `.SetSampler(new ParentBasedSampler(new HullThresholdSampler(() => station.HullIntegrity)))` on the tracer-provider builder.
- `GameDisplay` row 3 grew a multi-segment writer + sampler badge per UI §1.3 — column accounting `10 + 16 + 7 + 9 + 8 = 50`. Calm = `◌ idle` (DarkCyan), Storm = `◉ rec` (Red), "Sampler:" label Cyan.

PR2 of Scott's sprint-002 stack — **base branch is `feature/sprint-002-test-mode`** (#36) so the diff lands on top of TEST_MODE. Will retarget to `main` once #36 merges. Closes #33.

## Test plan
- [x] `dotnet test` — 72 passed (60 baseline + 6 TEST_MODE + 6 sampler tests)
- [x] All five spec-named tests + the PM hysteresis amendment + `OverrideSampler_TakesPriorityOverHull` (D2 hook smoke)
- [x] Smoke: `TEST_MODE=1 TEST_MAX_CYCLES=2 TEST_TICK_MS=50 dotnet run` — row 3 reads `Hull Integrity: 95%    Sampler: ◌ idle`
- [ ] Manual smoke against Aspire dashboard: trace volume drops above 75%, surges below 70%
- [ ] D2 (Chohfi) verifies `OverrideSampler` hookup in stacked PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)