### PR TITLE
Sprint 002 D2: SamplingBlindSpot strategy (#34)

### DIFF
--- a/docs/bug-catalog-debugging.md
+++ b/docs/bug-catalog-debugging.md
@@ -8,7 +8,7 @@ This cheat sheet is a walkthrough, not an answer key. For each bug it nudges you
 
 By default, one of the six strategies below is picked at random when the game starts. If you want to control it:
 
-- `BUG_STRATEGY=<name>` forces a specific strategy. Case-insensitive. Valid names: `LeakyRepair`, `LatencyInjection`, `SilentCounterCorruption`, `StickyCascadeMultiplier`, `WrongTargetDegradation`, `RetryStorm`. Unknown names exit with code 2 and print the valid list to stderr.
+- `BUG_STRATEGY=<name>` forces a specific strategy. Case-insensitive. Valid names: `LeakyRepair`, `LatencyInjection`, `SilentCounterCorruption`, `StickyCascadeMultiplier`, `WrongTargetDegradation`, `RetryStorm`, `SamplingBlindSpot`. Unknown names exit with code 2 and print the valid list to stderr.
 - `BUG_STRATEGY_SEED=<int>` seeds the RNG that picks both the target subsystem and the strategy. Same seed, same `(target, strategy)` pair. Only used when `BUG_STRATEGY` is unset.
 
 On startup the game logs `Bug strategy: <Name>, target: <Target>` so you know what was chosen. The mechanics of each strategy stay hidden, since figuring those out is the point.
@@ -95,3 +95,17 @@ Each section has the symptom you'll notice as a player, then a numbered walkthro
 4. Filter logs by "quota exhausted". How many entries show up inside a single cycle? Is one user click producing one entry, or many?
 
 *Teaches: sanity-checking counter rates against actual user actions. Ratio metrics. Spans record what the system attempted, not just what the user asked for, and that gap is where retry bugs live.*
+
+---
+
+## SamplingBlindSpot
+
+**Symptom:** the counter says N cascade failures but Traces show far fewer. The game-over screen even rubs your nose in it: `Cascade failures: 7  |  Traces captured: 1`.
+
+1. Open Metrics. Pull `station.cascade.failures`. Sum the rate over the session. Does the total line up with what the game-over screen reported?
+2. Switch to Traces, filter by `name=CascadeCheck`, count them over the same window. How does the trace count compare to the counter total?
+3. The mismatch is the bug. Counters and traces are independent pipelines — sampling decisions only touch traces. Where would you look to confirm the sampler is the cause?
+4. Open the `bug.strategy` resource attribute on any span you do still see. The strategy name is the giveaway, but what does the sampler config in `Program.cs` look like to make it land?
+5. Compare against `B2` — the hull-driven sampler should ramp up tracing on critical hull. Is it doing that, or is something pinning the rate low?
+
+*Teaches: head sampling makes its decision before the cascade tag exists, so it cannot bias toward errors. Counters and traces are independent — trace loss does not affect metric totals. This is the case for pairing head sampling with tail-based sampling and/or always-on error sampling in production.*

--- a/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
+++ b/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
@@ -10,6 +10,7 @@ public static class BugStrategyCatalog
         new StickyCascadeMultiplierStrategy(bugTarget),
         new WrongTargetDegradationStrategy(bugTarget),
         new RetryStormStrategy(bugTarget),
+        new SamplingBlindSpotStrategy(bugTarget),
     ];
 
     public static IBugStrategy? FindByName(IEnumerable<IBugStrategy> strategies, string name)

--- a/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/SamplingBlindSpotStrategy.cs
@@ -1,0 +1,14 @@
+namespace SpaceStationMonitor.BugStrategies;
+
+// All gameplay-side hooks (OnRepair, retries, cycle counter, cascade reset,
+// degradation redirect, repair delay) stay no-op. The visible effect comes
+// from a sidecar in Program.cs that swaps the sampler's OverrideSampler when
+// IsBugActive flips — see dev-design §0.5 (Path 2). Counters keep recording
+// at full fidelity; only spans drop, which is the teaching beat.
+public class SamplingBlindSpotStrategy : BugStrategyBase
+{
+    public SamplingBlindSpotStrategy(string bugTargetSubsystem, TimeSpan? activationDelay = null)
+        : base(bugTargetSubsystem, activationDelay) { }
+
+    public override string Name => "SamplingBlindSpot";
+}

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Trace;
 using SpaceStationMonitor.BugStrategies;
 using SpaceStationMonitor.Sampling;
 
@@ -76,6 +77,16 @@ public sealed class GameLoop
 
                 bool isBugActive = _repairSystem.IsBugActive;
 
+                // D2 sidecar (dev-design §0.5, Path 2). Idempotent per-cycle —
+                // the IsBugActive flip drives the override on, deactivation drives it off.
+                if (_sampler is not null)
+                {
+                    _sampler.OverrideSampler =
+                        _repairSystem.Strategy is SamplingBlindSpotStrategy && isBugActive
+                            ? new TraceIdRatioBasedSampler(0.05)
+                            : null;
+                }
+
                 using var cycleActivity = Telemetry.ActivitySource.StartActivity(
                     "StationCycle",
                     ActivityKind.Internal,
@@ -126,6 +137,12 @@ public sealed class GameLoop
                         new KeyValuePair<string, object?>("source.subsystem", cascade.SourceSubsystem),
                         new KeyValuePair<string, object?>("affected.subsystem",
                             string.Join(",", cascade.AffectedSubsystems)));
+
+                    _station.CascadeCount++;
+                    // IsAllDataRequested is the sampler decision, not a metric readback —
+                    // PM ratified this read for the SamplingBlindSpot reveal (dev-design §0.4).
+                    if (cascadeActivity != null && cascadeActivity.IsAllDataRequested)
+                        _station.CascadesTracedCount++;
 
                     _logger.LogError("Cascade failure: {Source} → {Affected}",
                         cascade.SourceSubsystem, string.Join(", ", cascade.AffectedSubsystems));

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -157,6 +157,7 @@ else
 }
 Console.WriteLine($"  Cycles survived: {station.CycleCount}");
 Console.WriteLine($"  Final hull integrity: {station.HullIntegrity:F1}%");
+Console.WriteLine($"  Cascade failures: {station.CascadeCount,-3}  |   Traces captured: {station.CascadesTracedCount,-3}");
 Console.ResetColor();
 
 logger.LogInformation("Game over — Cycles: {Cycles}, Hull: {Hull:F1}%",

--- a/src/SpaceStationMonitor/Station.cs
+++ b/src/SpaceStationMonitor/Station.cs
@@ -44,6 +44,9 @@ public class Station
     public int CycleCount { get; private set; }
     public DateTime StartTime { get; } = DateTime.UtcNow;
 
+    public int CascadeCount { get; internal set; }
+    public int CascadesTracedCount { get; internal set; }
+
     public double HullIntegrity =>
         Subsystems.Average(s => Math.Max(0, s.Health));
 

--- a/tests/SpaceStationMonitor.Tests/SamplingBlindSpotStrategyTests.cs
+++ b/tests/SpaceStationMonitor.Tests/SamplingBlindSpotStrategyTests.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using SpaceStationMonitor;
+using SpaceStationMonitor.BugStrategies;
+using SpaceStationMonitor.Sampling;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class SamplingBlindSpotStrategyTests
+{
+    private const string Target = "Oxygen";
+
+    [Fact]
+    public void Strategy_IsRegistered_InCatalog()
+    {
+        var strategies = BugStrategyCatalog.All(Target);
+
+        var found = BugStrategyCatalog.FindByName(strategies, "SamplingBlindSpot");
+
+        Assert.NotNull(found);
+        Assert.IsType<SamplingBlindSpotStrategy>(found);
+    }
+
+    [Fact]
+    public void OnRepair_IsNoOp_ReturnsRequestedUnchanged()
+    {
+        // Effect lives in the sidecar (Program.cs), not in the IBugStrategy hooks.
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0) { Health = 50 };
+        int retryCount = 0;
+
+        var applied = strategy.OnRepair(sub, 25, ref retryCount);
+
+        Assert.Equal(25, applied);
+        Assert.Equal(0, retryCount);
+    }
+
+    [Fact]
+    public void ShouldRetryAfterFailure_AlwaysFalse()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0);
+
+        Assert.False(strategy.ShouldRetryAfterFailure(sub, 0));
+        Assert.False(strategy.ShouldRetryAfterFailure(sub, 5));
+    }
+
+    [Fact]
+    public void CycleCounterIncrement_AlwaysOne()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+
+        Assert.Equal(1, strategy.CycleCounterIncrement());
+    }
+
+    [Fact]
+    public void RedirectDegradationTarget_DoesNotRedirect()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0);
+        var all = new[] { sub, new Subsystem("Power", 1.0) };
+
+        var redirected = strategy.RedirectDegradationTarget(sub, all);
+
+        Assert.Same(sub, redirected);
+    }
+
+    [Fact]
+    public void RepairDelay_IsNull()
+    {
+        var strategy = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        var sub = new Subsystem(Target, 1.0);
+
+        Assert.Null(strategy.RepairDelay(sub));
+    }
+
+    [Fact]
+    public void IsBugActive_RespectsActivationDelay()
+    {
+        var notYet = new SamplingBlindSpotStrategy(Target, TimeSpan.FromMinutes(1));
+        var alreadyActive = new SamplingBlindSpotStrategy(Target, TimeSpan.Zero);
+        // BugStrategyBase compares DateTime.UtcNow to its captured _startTime,
+        // so a 1-tick delay is enough to flip the predicate by the time we read it.
+        Thread.Sleep(2);
+
+        Assert.False(notYet.IsBugActive);
+        Assert.True(alreadyActive.IsBugActive);
+    }
+
+    // AC5 — sampler-coupled tests: the strategy's effect is observed at the
+    // HullThresholdSampler.OverrideSampler boundary, not on the strategy itself.
+    // The sidecar in GameLoop.cs assigns/clears OverrideSampler per cycle; here
+    // we drive the same toggle directly so the test is independent of the loop.
+
+    [Fact]
+    public void StrategyInactive_SamplerBehavesPerB2Spec()
+    {
+        // Mirrors B2 AC2 — Storm at hull ≤ 70 returns RecordAndSample;
+        // Calm at hull > 75 returns the 10% ratio sampler decision.
+        var hull = 30.0;
+        var sampler = new HullThresholdSampler(() => hull);
+        // sampler.OverrideSampler stays null — strategy effect not active.
+
+        Assert.Equal(SamplingDecision.RecordAndSample,
+            sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
+
+        hull = 100.0;
+        // Lift hull above the calm threshold then drive the sampler past one
+        // call so the regime transition catches up before we read.
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+
+        // At hull=100 the underlying ratio sampler dominates. Just confirm
+        // that ShouldSample respects the override-null path (not pinned at 5%).
+        // We don't probabilistically assert the 10% rate here — that's B2's plate.
+        int sampled = 0;
+        var rng = new Random(7);
+        for (int i = 0; i < 100; i++)
+        {
+            var traceId = MakeTraceId(rng);
+            if (sampler.ShouldSample(MakeParams(traceId)).Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+        // 10% binomial → mean 10, σ ≈ 3. <25 is comfortably outside the 5% pin.
+        Assert.True(sampled < 25,
+            $"inactive override should fall through to ~10% ratio; got {sampled}/100");
+    }
+
+    [Fact]
+    public void StrategyActive_RoutesEverythingThroughFivePercent_RegardlessOfHull()
+    {
+        var hull = 30.0; // Storm regime — would normally RecordAndSample.
+        var sampler = new HullThresholdSampler(() => hull);
+
+        // Activate D2's sidecar effect.
+        sampler.OverrideSampler = new TraceIdRatioBasedSampler(0.05);
+
+        int sampled = 0;
+        var rng = new Random(11);
+        for (int i = 0; i < 200; i++)
+        {
+            var traceId = MakeTraceId(rng);
+            if (sampler.ShouldSample(MakeParams(traceId)).Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+
+        // 5% × 200 → mean 10. p(>=25 sampled) ≪ 0.001. The hull=30 Storm
+        // path would have given 200/200 if the override hadn't intercepted.
+        Assert.True(sampled < 25,
+            $"active override should pin to ~5% regardless of Storm hull; got {sampled}/200");
+    }
+
+    [Fact]
+    public void Activation_IsReversible_WhenOverrideClearsHullPathReturns()
+    {
+        var hull = 30.0;
+        var sampler = new HullThresholdSampler(() => hull);
+
+        // Activate.
+        sampler.OverrideSampler = new TraceIdRatioBasedSampler(0.05);
+
+        // Deactivate — sidecar nulls it out when the strategy stops being active.
+        sampler.OverrideSampler = null;
+
+        // hull=30 → Storm → RecordAndSample once again.
+        Assert.Equal(SamplingDecision.RecordAndSample,
+            sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom())).Decision);
+
+        // And lift hull above the calm threshold; now it falls back to the
+        // ratio sampler. Driver call to settle the regime transition.
+        hull = 100.0;
+        sampler.ShouldSample(MakeParams(ActivityTraceId.CreateRandom()));
+
+        int sampled = 0;
+        var rng = new Random(23);
+        for (int i = 0; i < 100; i++)
+        {
+            var traceId = MakeTraceId(rng);
+            if (sampler.ShouldSample(MakeParams(traceId)).Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+        // After deactivation, calm hull → ~10% rate, not the 5% pin.
+        Assert.True(sampled < 25,
+            $"deactivated sampler should follow B2 hull behavior; got {sampled}/100");
+    }
+
+    private static ActivityTraceId MakeTraceId(Random rng)
+    {
+        var bytes = new byte[16];
+        rng.NextBytes(bytes);
+        return ActivityTraceId.CreateFromBytes(bytes);
+    }
+
+    private static SamplingParameters MakeParams(ActivityTraceId traceId) =>
+        new(parentContext: default,
+            traceId: traceId,
+            name: "CascadeCheck",
+            kind: ActivityKind.Internal);
+
+    // AC6 — statistical: 100 cascade events with the strategy active sample <15.
+    // We exercise TraceIdRatioBasedSampler(0.05) directly because the sidecar
+    // (Program.cs) hands that exact sampler to HullThresholdSampler.OverrideSampler
+    // when SamplingBlindSpot activates. p(>=15 sampled at p=0.05) is well under
+    // 0.001 — false-positive rate is negligible. Seeded RNG keeps the test
+    // deterministic across runs.
+    [Fact]
+    public void Sampling_AtFivePercent_DropsCascadeTraces()
+    {
+        var sampler = new TraceIdRatioBasedSampler(0.05);
+        var rng = new Random(42);
+        int sampled = 0;
+
+        for (int i = 0; i < 100; i++)
+        {
+            var traceIdBytes = new byte[16];
+            rng.NextBytes(traceIdBytes);
+            var traceId = ActivityTraceId.CreateFromBytes(traceIdBytes);
+
+            var parameters = new SamplingParameters(
+                parentContext: default,
+                traceId: traceId,
+                name: "CascadeCheck",
+                kind: ActivityKind.Internal);
+
+            var result = sampler.ShouldSample(in parameters);
+            if (result.Decision == SamplingDecision.RecordAndSample)
+                sampled++;
+        }
+
+        Assert.True(sampled < 15,
+            $"expected <15 of 100 cascade events to be sampled at 5%, got {sampled}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements **D2 SamplingBlindSpot** per `Dev Design/2026-04-25-sprint-002-task-breakdown.md` §2.2 and §2.5, and `Research/2026-04-25-sprint-002-requirements.md` §D2 (AC1-AC7).

A new `IBugStrategy` that, when active, hijacks Scott's `HullThresholdSampler` (B2, #38) via `OverrideSampler = TraceIdRatioBasedSampler(0.05)` — counters keep recording cascade failures at full fidelity, but spans drop statistically. The teaching beat lands at game-over: counter says N failures, traces show ≪ N.

- New `SamplingBlindSpotStrategy` (no-op IBugStrategy hooks; effect lives in sidecar per dev-design §0.5 Path 2)
- Registered in `BugStrategyCatalog` (`BUG_STRATEGY=SamplingBlindSpot` works)
- `Station.CascadeCount` + `Station.CascadesTracedCount` (`int { get; internal set; }`)
- Sidecar in `GameLoop.cs`: per-cycle, after `bool isBugActive` snapshot — sets/clears `OverrideSampler` based on strategy + active state
- Cascade-loop increments: `_station.CascadeCount++` and `if (cascadeActivity?.IsAllDataRequested == true) _station.CascadesTracedCount++` (PM-ratified Activity-shape inspection per dev-design §0.4)
- Game-over reveal in `Program.cs`: `Cascade failures: {N,-3}  |   Traces captured: {M,-3}` directly under `Final hull integrity:` per UI spec §3.2 (default colors — dissonance is the teaching beat)
- Cheat-sheet entry in `docs/bug-catalog-debugging.md` matches existing strategy walkthrough style

## Test plan

11 unit tests in `SamplingBlindSpotStrategyTests.cs`, all passing locally; full suite 83/83 green:

- [x] Strategy registered in catalog (selectable via env var)
- [x] No-op contract (`OnRepair` pass-through, `ShouldRetryAfterFailure=false`, `CycleCounterIncrement=1`, no degradation redirect, null repair delay, activation gate respects delay)
- [x] **AC5** — `StrategyInactive_SamplerBehavesPerB2Spec`: hull=30 → RecordAndSample; hull=100 → ratio sampler dominates (<25/100 sampled)
- [x] **AC5** — `StrategyActive_RoutesEverythingThroughFivePercent_RegardlessOfHull`: hull=30 Storm + override → still ~5% (200 seeded TraceIds, <25 sampled)
- [x] **AC5** — `Activation_IsReversible_WhenOverrideClearsHullPathReturns`: clear override → hull=30 → RecordAndSample again; hull=100 → falls back to ratio
- [x] **AC6** statistical — `Sampling_AtFivePercent_DropsCascadeTraces`: `TraceIdRatioBasedSampler(0.05)` × 100 seeded TraceIds → <15 sampled (deterministic with seed 42; p ≪ 0.001 of false positive)

Manual smoke: existing `dotnet build` + `dotnet test` green against B2's branch.

## Notes for QA

- **Base branch is `feature/sprint-002-b2-sampler` (#38)** — will retarget to `main` after #38 merges.
- **Intentional duplicate in initial diff:** `Station.CascadeCount` declaration. Per dev-design §2.3, Fernando's PR #37 also declares this property. PM-locked sequence: when #37 merges to main, this branch rebases and **force-pushes** to drop the duplicate (single-author branch). Increments + `CascadesTracedCount` + sidecar + tests all stay. Re-run unit tests post-rebase to confirm no regression — should be a clean no-op diff beyond the declaration drop.
- Game-over screen rendering: my `Cascade failures | Traces captured` line goes ABOVE Fernando's `Achievements: N — names` line (B3, #37) per dev-design §2.5. Verify both coexist after the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)