### PR TITLE
B3 follow-up: XML doc on Achievement + AchievementSystem

### DIFF
--- a/src/SpaceStationMonitor/Achievements/Achievement.cs
+++ b/src/SpaceStationMonitor/Achievements/Achievement.cs
@@ -1,3 +1,9 @@
 namespace SpaceStationMonitor.Achievements;
 
+/// <summary>
+/// A session-scoped achievement defined by a predicate over <see cref="Station"/> state.
+/// </summary>
+/// <param name="Name">Stable identifier used as the achievement key and emitted as the <c>achievement.name</c> attribute.</param>
+/// <param name="Description">Player-facing description shown on unlock.</param>
+/// <param name="Predicate">Returns true when the achievement should fire for the given station state.</param>
 public sealed record Achievement(string Name, string Description, Func<Station, bool> Predicate);

--- a/src/SpaceStationMonitor/Achievements/AchievementSystem.cs
+++ b/src/SpaceStationMonitor/Achievements/AchievementSystem.cs
@@ -3,6 +3,9 @@ using Microsoft.Extensions.Logging;
 
 namespace SpaceStationMonitor.Achievements;
 
+/// <summary>
+/// Tracks which achievements have unlocked during the current session and fires each at most once.
+/// </summary>
 public class AchievementSystem
 {
     private readonly HashSet<string> _unlocked = new();
@@ -44,8 +47,22 @@ public class AchievementSystem
         };
     }
 
+    /// <summary>
+    /// Names of achievements unlocked during the current session.
+    /// </summary>
     public IReadOnlyCollection<string> UnlockedNames => _unlocked;
 
+    /// <summary>
+    /// Evaluates each achievement against the given station state. Newly satisfied achievements are
+    /// marked unlocked, increment the <c>station.achievements.unlocked</c> counter, attach an
+    /// <c>AchievementUnlocked</c> span event to <paramref name="cycleSpan"/> when it is non-null,
+    /// push their name onto the display toast, and log at Information. Already-unlocked
+    /// achievements are skipped.
+    /// </summary>
+    /// <param name="station">Source of state for predicate evaluation.</param>
+    /// <param name="cycleSpan">Optional active span to receive the unlock event.</param>
+    /// <param name="logger">Logger for the unlock notification.</param>
+    /// <param name="display">Display surface that renders the achievement toast.</param>
     public void CheckAndFire(Station station, Activity? cycleSpan, ILogger logger, GameDisplay display)
     {
         foreach (var achievement in _achievements)


### PR DESCRIPTION
## Summary

Follow-up to PR #37 (Issue #35, Sprint 002 B3, already merged). Addresses the user's pre-merge inline comment on `Achievements/AchievementSystem.cs:6` requesting XML doc on the new classes and methods.

Adds `///` summaries on:
- `Achievement` record (class summary + positional `<param>` for `Name`, `Description`, `Predicate`)
- `AchievementSystem` class
- `AchievementSystem.UnlockedNames` getter
- `AchievementSystem.CheckAndFire` (class summary + per-parameter doc)

Style is contract-only: no codebase-internal references, no em-dashes, no phantom spec refs, no restate-the-code narration. The trivial parameterless ctor is left undocumented.

Issue #35 stays Done — this is a bonus cleanup, not a re-open.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 75/75 green
- [ ] Reviewer eyeballs the doc text for tone, jargon, and contract accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)