### PR TITLE
Sprint 003 #40: BUG_ACTIVATION_DELAY_MS env-var foundation

### DIFF
--- a/src/SpaceStationMonitor/BugStrategies/BugSelector.cs
+++ b/src/SpaceStationMonitor/BugStrategies/BugSelector.cs
@@ -12,13 +12,14 @@ public static class BugSelector
     // seed-driven).
     public static (string target, IBugStrategy strategy) Select(
         Func<string, string?> env,
-        string[] subsystemNames)
+        string[] subsystemNames,
+        TimeSpan? activationDelay = null)
     {
         var seedEnv = env("BUG_STRATEGY_SEED");
         var rng = int.TryParse(seedEnv, out var seed) ? new Random(seed) : new Random();
 
         var target = subsystemNames[rng.Next(subsystemNames.Length)];
-        var strategies = BugStrategyCatalog.All(target);
+        var strategies = BugStrategyCatalog.All(target, activationDelay);
 
         var forcedName = env("BUG_STRATEGY");
         if (!string.IsNullOrWhiteSpace(forcedName))

--- a/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
+++ b/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
@@ -2,15 +2,19 @@ namespace SpaceStationMonitor.BugStrategies;
 
 public static class BugStrategyCatalog
 {
-    public static IBugStrategy[] All(string bugTarget) =>
+    // activationDelay = null lets each strategy use its BugStrategyBase default
+    // (currently 2 minutes). A non-null value overrides every strategy in the run
+    // uniformly — used by the BUG_ACTIVATION_DELAY_MS env-var path so QA / CI can
+    // exercise post-bug behavior without sitting through the production-tuned wait.
+    public static IBugStrategy[] All(string bugTarget, TimeSpan? activationDelay = null) =>
     [
-        new LeakyRepairStrategy(bugTarget),
-        new LatencyInjectionStrategy(bugTarget),
-        new SilentCounterCorruptionStrategy(bugTarget),
-        new StickyCascadeMultiplierStrategy(bugTarget),
-        new WrongTargetDegradationStrategy(bugTarget),
-        new RetryStormStrategy(bugTarget),
-        new SamplingBlindSpotStrategy(bugTarget),
+        new LeakyRepairStrategy(bugTarget, activationDelay),
+        new LatencyInjectionStrategy(bugTarget, activationDelay),
+        new SilentCounterCorruptionStrategy(bugTarget, activationDelay),
+        new StickyCascadeMultiplierStrategy(bugTarget, activationDelay),
+        new WrongTargetDegradationStrategy(bugTarget, activationDelay),
+        new RetryStormStrategy(bugTarget, activationDelay),
+        new SamplingBlindSpotStrategy(bugTarget, activationDelay),
     ];
 
     public static IBugStrategy? FindByName(IEnumerable<IBugStrategy> strategies, string name)

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -13,6 +13,21 @@ using SpaceStationMonitor.Sampling;
 // ── Test-mode flags (parsed once at startup) ────────────────────────────────
 var testConfig = TestModeConfig.FromEnvironment(Environment.GetEnvironmentVariable);
 
+// ── BUG_ACTIVATION_DELAY_MS (parsed once at startup) ────────────────────────
+// Optional env-var override for every strategy's activation delay. Lets QA / CI
+// exercise post-bug behavior without sitting through the production-tuned wait.
+// Unset, empty, non-integer, or negative all fall back to the per-strategy default.
+var bugDelayRaw = Environment.GetEnvironmentVariable("BUG_ACTIVATION_DELAY_MS");
+TimeSpan? bugActivationDelay = null;
+bool bugDelayInvalid = false;
+if (!string.IsNullOrEmpty(bugDelayRaw))
+{
+    if (int.TryParse(bugDelayRaw, out var bugDelayMs) && bugDelayMs >= 0)
+        bugActivationDelay = TimeSpan.FromMilliseconds(bugDelayMs);
+    else
+        bugDelayInvalid = true;
+}
+
 // ── Splash gate ─────────────────────────────────────────────────────────────
 using var shutdownCts = new CancellationTokenSource();
 Console.CancelKeyPress += (_, e) =>
@@ -66,7 +81,7 @@ string bugTarget;
 IBugStrategy strategy;
 try
 {
-    (bugTarget, strategy) = BugSelector.Select(Environment.GetEnvironmentVariable, subsystemNames);
+    (bugTarget, strategy) = BugSelector.Select(Environment.GetEnvironmentVariable, subsystemNames, bugActivationDelay);
 }
 catch (InvalidOperationException ex)
 {
@@ -118,6 +133,13 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 });
 
 var logger = loggerFactory.CreateLogger("SpaceStationMonitor");
+
+if (bugDelayInvalid)
+{
+    logger.LogWarning(
+        "Ignoring invalid BUG_ACTIVATION_DELAY_MS={Value}; expected a non-negative integer. Using per-strategy default.",
+        bugDelayRaw);
+}
 
 // ── Register gauge metrics (need Station reference) ─────────────────────────
 Telemetry.Meter.CreateObservableGauge("station.subsystem.health",

--- a/tests/SpaceStationMonitor.Tests/BugStrategyCatalogTests.cs
+++ b/tests/SpaceStationMonitor.Tests/BugStrategyCatalogTests.cs
@@ -39,4 +39,33 @@ public class BugStrategyCatalogTests
             Assert.Same(s, found);
         }
     }
+
+    [Fact]
+    public void All_WithDelayOverride_PassesOverrideToAllStrategies()
+    {
+        // 100ms delay + 200ms wait crosses the activation threshold for every strategy.
+        var strategies = BugStrategyCatalog.All("Oxygen", TimeSpan.FromMilliseconds(100));
+
+        Thread.Sleep(200);
+
+        foreach (var s in strategies)
+        {
+            Assert.True(s.IsBugActive,
+                $"strategy '{s.Name}' should be active 200ms after construction with 100ms override");
+        }
+    }
+
+    [Fact]
+    public void All_WithNullDelay_UsesDefault()
+    {
+        // Null override falls through to BugStrategyBase's 2-minute production default;
+        // none of the strategies should report active immediately after construction.
+        var strategies = BugStrategyCatalog.All("Oxygen", activationDelay: null);
+
+        foreach (var s in strategies)
+        {
+            Assert.False(s.IsBugActive,
+                $"strategy '{s.Name}' should not be active immediately when delay is left at the default");
+        }
+    }
 }

--- a/tests/SpaceStationMonitor.Tests/TestModeTests.cs
+++ b/tests/SpaceStationMonitor.Tests/TestModeTests.cs
@@ -132,10 +132,39 @@ public class TestModeTests
         Assert.Equal(0, station.CycleCount);
     }
 
-    private static (GameLoop loop, Station station) BuildLoop(TestModeConfig config)
+    [Fact]
+    public async Task TestMode_WithBugActivationDelay_StrategyActivatesWithinCycles()
+    {
+        // AC5 — BUG_ACTIVATION_DELAY_MS=100 + 32 cycles at 10ms tick crosses the
+        // activation threshold by ~cycle 11. Drives the env-var path through
+        // BugSelector → BugStrategyCatalog → strategy ctor end-to-end so the
+        // wire-up is exercised, not just the catalog unit boundary. Seeded so the
+        // strategy pick is deterministic across runs.
+        var env = new Dictionary<string, string?> { ["BUG_STRATEGY_SEED"] = "1" };
+        var (_, strategy) = BugSelector.Select(
+            k => env.GetValueOrDefault(k),
+            new[] { "Oxygen", "Power", "Shields", "Thermal" },
+            TimeSpan.FromMilliseconds(100));
+
+        Assert.False(strategy.IsBugActive);
+
+        var (loop, station) = BuildLoopWithStrategy(strategy, new TestModeConfig(
+            TestMode: true, MaxCycles: 32, TickInterval: TimeSpan.FromMilliseconds(10)));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        Assert.True(strategy.IsBugActive,
+            $"strategy '{strategy.Name}' should activate within 32×10ms cycles given 100ms delay");
+    }
+
+    private static (GameLoop loop, Station station) BuildLoop(TestModeConfig config) =>
+        BuildLoopWithStrategy(new NoOpBugStrategy(), config);
+
+    private static (GameLoop loop, Station station) BuildLoopWithStrategy(
+        IBugStrategy strategy, TestModeConfig config)
     {
         var station = new Station();
-        var strategy = new NoOpBugStrategy();
         var repairSystem = new RepairSystem(strategy);
         var eventEngine = new EventEngine();
         var cascadeEngine = new CascadeEngine(strategy);


### PR DESCRIPTION
## Summary

Adds the `BUG_ACTIVATION_DELAY_MS` env-var foundation per `Research/2026-04-26-sprint-003-requirements.md` §#40 (AC1-AC6) and `Dev Design/2026-04-26-sprint-003-task-breakdown.md` §2.3.

Optional env-var override for every bug strategy's activation delay. Lets QA / CI / smoke-test runs exercise post-bug behavior without sitting through the production-tuned 2-minute wait. Sprint 002 already has the per-strategy delay parameter (`TimeSpan? activationDelay`) plumbed through every strategy ctor — this PR adds the catalog + selector + Program.cs glue to thread an env-driven override into that path.

## Pipeline

```
Program.cs parses BUG_ACTIVATION_DELAY_MS once at startup
  └─ optional TimeSpan? threaded through BugSelector.Select(env, names, activationDelay)
       └─ forwarded to BugStrategyCatalog.All(target, activationDelay)
            └─ each strategy ctor receives the override (existing 2nd parameter, Sprint 001 baseline)
```

## Behavior

| Input | Resulting delay | Notes |
|---|---|---|
| Unset / empty | per-strategy default (2 min) | byte-for-byte Sprint 001 baseline |
| `BUG_ACTIVATION_DELAY_MS=N` (non-negative int) | `N` ms | uniform across all 7 strategies |
| `BUG_ACTIVATION_DELAY_MS=0` | 0 ms | activates on first cycle |
| Non-integer / negative | per-strategy default | one startup warning logged via `ILogger`, naming the offending value |

## Test plan

- [x] `BugStrategyCatalogTests.All_WithDelayOverride_PassesOverrideToAllStrategies` — 100ms override + 200ms wait → every strategy `IsBugActive`
- [x] `BugStrategyCatalogTests.All_WithNullDelay_UsesDefault` — null override → no strategy active immediately (default 2-min)
- [x] `TestModeTests.TestMode_WithBugActivationDelay_StrategyActivatesWithinCycles` — seeded `BugSelector.Select` + GameLoop with 32×10ms cycles + 100ms delay → activation is observable end-to-end through the loop, not just at the catalog boundary
- [x] 103/103 full suite passes (was 100; +3 from this PR)
- [x] `dotnet build` clean

## Coordination notes

- Scott's B2 (#44) consumes the new `BugStrategyCatalog.All(target, activationDelay)` signature for mode-aware activation timing. Default value (`null`) keeps existing call sites working until Scott rebases on this.
- D1 stretch (#45, conditional) registers a new strategy in the catalog; that addition will compose with this signature without reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)