### PR TITLE
Sprint 003 #43: TailSamplingProcessor + exemplar filter

### DIFF
--- a/docs/bug-catalog-debugging.md
+++ b/docs/bug-catalog-debugging.md
@@ -109,3 +109,26 @@ Each section has the symptom you'll notice as a player, then a numbered walkthro
 5. Compare against `B2` — the hull-driven sampler should ramp up tracing on critical hull. Is it doing that, or is something pinning the rate low?
 
 *Teaches: head sampling makes its decision before the cascade tag exists, so it cannot bias toward errors. Counters and traces are independent — trace loss does not affect metric totals. This is the case for pairing head sampling with tail-based sampling and/or always-on error sampling in production.*
+
+
+---
+
+## Sampling — head vs tail, and where each lives
+
+The space station has two sampling stages:
+
+- **Head sampler** — runs at span start, before any tag is set. Sees the span name and the parent context, nothing else. Uses cheap inputs to make a fast decision: keep this one, drop this one. The hull-driven sampler in `B2` and the rules-based sampler in Expert mode are head samplers.
+- **Tail sampler** — runs after the trace has finished and every span has set its tags. Sees the whole trace at once and can keep traces that contain errors / cascades / failed repairs even if a head sampler would have dropped them. Hard mode wires in `TailSamplingProcessor` for this.
+
+A head sampler can never decide on a tag it has not seen yet. That is the whole reason `SamplingBlindSpot` works as a teaching beat — head sampling at a low rate cannot bias toward errors, because the error tag does not exist when the decision is made.
+
+**Where tail sampling lives in real production:** in the **OpenTelemetry Collector**, not in your application process. The collector runs as a sidecar or as a fleet-wide service, sees traces from every instance of every service, and can make consistent tail decisions across the whole fleet. The `TailSamplingProcessor` in this codebase is a single-process teaching simulation; it cannot make cross-process decisions and it holds buffered spans in memory of the game itself. **Do not carry the in-process pattern into a production service.** If you want tail sampling in production, run a collector with the `tail_sampling` processor configured.
+
+**Exemplars** are the bridge from a metric data point back to a representative trace. With `.SetExemplarFilter(ExemplarFilterType.TraceBased)` on the `MeterProviderBuilder`, the SDK attaches a TraceId to a small sample of measurements per histogram bucket. Click a slow bucket on `station.repair.effectiveness` in Aspire, follow the exemplar marker, land on a real trace. That closes the metric → trace investigation loop.
+
+1. Open Metrics. Find a histogram bucket that looks anomalous on `station.repair.effectiveness` (e.g. effectiveness < 50%).
+2. Click the bucket. The exemplar marker links to a TraceId — open it.
+3. The trace shows the actual `RepairAction` span where the bug fired. From there, the usual span-events / tags / linked logs walk applies.
+4. If exemplars are missing on a bucket you expected to find one in, check that the head sampler at game start was not `AlwaysOff` and that the trace was not dropped by tail sampling.
+
+*Teaches: head and tail sampling answer different questions. Exemplars are the metric → trace bridge that keeps a low sample rate from hiding the trace you actually want. Production tail sampling lives in the collector; the in-game implementation is a single-process simulation.*

--- a/docs/bug-catalog-debugging.md
+++ b/docs/bug-catalog-debugging.md
@@ -113,21 +113,21 @@ Each section has the symptom you'll notice as a player, then a numbered walkthro
 
 ---
 
-## Sampling — head vs tail, and where each lives
+## Sampling: head vs tail, and where each lives
 
 The space station has two sampling stages:
 
-- **Head sampler** — runs at span start, before any tag is set. Sees the span name and the parent context, nothing else. Uses cheap inputs to make a fast decision: keep this one, drop this one. The hull-driven sampler in `B2` and the rules-based sampler in Expert mode are head samplers.
-- **Tail sampler** — runs after the trace has finished and every span has set its tags. Sees the whole trace at once and can keep traces that contain errors / cascades / failed repairs even if a head sampler would have dropped them. Hard mode wires in `TailSamplingProcessor` for this.
+- **Head sampler**: runs at span start, before any tag is set. Sees the span name and the parent context, nothing else. Uses cheap inputs to make a fast decision: keep this one, drop this one. In general, any sampler that decides at span creation time is a head sampler.
+- **Tail sampler**: runs after the trace has finished and every span has set its tags. Sees the whole trace at once and can keep traces that contain errors / cascades / failed repairs even if a head sampler would have dropped them. Treat tail sampling here as a conceptual contrast with head sampling; mode-specific wiring is introduced in a follow-up change.
 
-A head sampler can never decide on a tag it has not seen yet. That is the whole reason `SamplingBlindSpot` works as a teaching beat — head sampling at a low rate cannot bias toward errors, because the error tag does not exist when the decision is made.
+A head sampler can never decide on a tag it has not seen yet. That is the whole reason `SamplingBlindSpot` works as a teaching beat. Head sampling at a low rate cannot bias toward errors, because the error tag does not exist when the decision is made.
 
 **Where tail sampling lives in real production:** in the **OpenTelemetry Collector**, not in your application process. The collector runs as a sidecar or as a fleet-wide service, sees traces from every instance of every service, and can make consistent tail decisions across the whole fleet. The `TailSamplingProcessor` in this codebase is a single-process teaching simulation; it cannot make cross-process decisions and it holds buffered spans in memory of the game itself. **Do not carry the in-process pattern into a production service.** If you want tail sampling in production, run a collector with the `tail_sampling` processor configured.
 
 **Exemplars** are the bridge from a metric data point back to a representative trace. With `.SetExemplarFilter(ExemplarFilterType.TraceBased)` on the `MeterProviderBuilder`, the SDK attaches a TraceId to a small sample of measurements per histogram bucket. Click a slow bucket on `station.repair.effectiveness` in Aspire, follow the exemplar marker, land on a real trace. That closes the metric → trace investigation loop.
 
 1. Open Metrics. Find a histogram bucket that looks anomalous on `station.repair.effectiveness` (e.g. effectiveness < 50%).
-2. Click the bucket. The exemplar marker links to a TraceId — open it.
+2. Click the bucket. The exemplar marker links to a TraceId. Open it.
 3. The trace shows the actual `RepairAction` span where the bug fired. From there, the usual span-events / tags / linked logs walk applies.
 4. If exemplars are missing on a bucket you expected to find one in, check that the head sampler at game start was not `AlwaysOff` and that the trace was not dropped by tail sampling.
 

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -102,6 +102,7 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .SetResourceBuilder(resourceBuilder)
     .AddMeter(Telemetry.MeterName)
+    .SetExemplarFilter(ExemplarFilterType.TraceBased)
     .AddOtlpExporter()
     .Build();
 

--- a/src/SpaceStationMonitor/Sampling/TailSamplingProcessor.cs
+++ b/src/SpaceStationMonitor/Sampling/TailSamplingProcessor.cs
@@ -18,7 +18,7 @@ public enum TailSamplingDecision
 /// decides keep/drop on root-span end + grace window. Errors, cascade-triggered traces, and
 /// failed-repair traces are kept; everything else falls into a 25% TraceId-hash sample.
 /// Real production tail sampling lives in the OpenTelemetry collector; this is a teaching
-/// simulation suitable for a single-process console app — see docs/bug-catalog-debugging.md.
+/// simulation suitable for a single-process console app. See docs/bug-catalog-debugging.md.
 /// </summary>
 public sealed class TailSamplingProcessor : BaseProcessor<Activity>
 {

--- a/src/SpaceStationMonitor/Sampling/TailSamplingProcessor.cs
+++ b/src/SpaceStationMonitor/Sampling/TailSamplingProcessor.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace SpaceStationMonitor.Sampling;
+
+/// <summary>
+/// Decision recorded by the tail sampler for a given trace.
+/// </summary>
+public enum TailSamplingDecision
+{
+    Pending,
+    Kept,
+    Dropped,
+}
+
+/// <summary>
+/// In-process tail-sampling processor. Buffers activities by <see cref="Activity.TraceId"/>,
+/// decides keep/drop on root-span end + grace window. Errors, cascade-triggered traces, and
+/// failed-repair traces are kept; everything else falls into a 25% TraceId-hash sample.
+/// Real production tail sampling lives in the OpenTelemetry collector; this is a teaching
+/// simulation suitable for a single-process console app — see docs/bug-catalog-debugging.md.
+/// </summary>
+public sealed class TailSamplingProcessor : BaseProcessor<Activity>
+{
+    public const int DefaultBufferCap = 1000;
+    public static readonly TimeSpan DefaultGraceWindow = TimeSpan.FromMilliseconds(200);
+    private const double SampleRatio = 0.25;
+
+    private readonly BaseProcessor<Activity>? _next;
+    private readonly int _bufferCap;
+    private readonly TimeSpan _graceWindow;
+    private readonly Func<DateTime> _now;
+
+    private readonly object _lock = new();
+    private readonly Dictionary<ActivityTraceId, TraceBuffer> _buffers = new();
+    private readonly LinkedList<ActivityTraceId> _insertionOrder = new();
+    private readonly Dictionary<ActivityTraceId, TailSamplingDecision> _decisions = new();
+
+    public TailSamplingProcessor(
+        BaseProcessor<Activity>? next = null,
+        int bufferCap = DefaultBufferCap,
+        TimeSpan? graceWindow = null,
+        Func<DateTime>? nowProvider = null)
+    {
+        if (bufferCap <= 0) throw new ArgumentOutOfRangeException(nameof(bufferCap));
+        _next = next;
+        _bufferCap = bufferCap;
+        _graceWindow = graceWindow ?? DefaultGraceWindow;
+        _now = nowProvider ?? (() => DateTime.UtcNow);
+    }
+
+    public override void OnEnd(Activity data)
+    {
+        lock (_lock)
+        {
+            FlushExpiredLocked();
+
+            var traceId = data.TraceId;
+            if (!_buffers.TryGetValue(traceId, out var buffer))
+            {
+                if (_buffers.Count >= _bufferCap)
+                {
+                    var oldestNode = _insertionOrder.First;
+                    if (oldestNode is not null)
+                    {
+                        _insertionOrder.RemoveFirst();
+                        DecideAndForwardLocked(oldestNode.Value);
+                    }
+                }
+                buffer = new TraceBuffer();
+                _buffers[traceId] = buffer;
+                _insertionOrder.AddLast(traceId);
+            }
+
+            buffer.Activities.Add(data);
+            if (data.Parent is null)
+            {
+                buffer.RootSeen = true;
+                buffer.RootEndTime = _now();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Last-recorded decision for the given trace, or <see cref="TailSamplingDecision.Pending"/>
+    /// if the trace is still buffered or unseen.
+    /// </summary>
+    public TailSamplingDecision GetDecision(ActivityTraceId traceId)
+    {
+        lock (_lock)
+        {
+            FlushExpiredLocked();
+            return _decisions.TryGetValue(traceId, out var d) ? d : TailSamplingDecision.Pending;
+        }
+    }
+
+    /// <summary>
+    /// Decides any traces whose root span ended more than the grace window ago. Driven naturally
+    /// by inbound <see cref="OnEnd"/> calls in production; tests call this directly to avoid
+    /// real-time waits.
+    /// </summary>
+    public void FlushExpired()
+    {
+        lock (_lock) FlushExpiredLocked();
+    }
+
+    private void FlushExpiredLocked()
+    {
+        var now = _now();
+        List<ActivityTraceId>? toDecide = null;
+        foreach (var (id, buf) in _buffers)
+        {
+            if (buf.RootSeen && (now - buf.RootEndTime) >= _graceWindow)
+                (toDecide ??= new()).Add(id);
+        }
+        if (toDecide is null) return;
+        foreach (var id in toDecide)
+        {
+            _insertionOrder.Remove(id);
+            DecideAndForwardLocked(id);
+        }
+    }
+
+    private void DecideAndForwardLocked(ActivityTraceId traceId)
+    {
+        if (!_buffers.Remove(traceId, out var buffer)) return;
+
+        bool keep = ShouldKeep(buffer.Activities, traceId);
+        _decisions[traceId] = keep ? TailSamplingDecision.Kept : TailSamplingDecision.Dropped;
+
+        if (keep && _next is not null)
+        {
+            foreach (var act in buffer.Activities)
+                _next.OnEnd(act);
+        }
+    }
+
+    internal static bool ShouldKeep(IEnumerable<Activity> activities, ActivityTraceId traceId)
+    {
+        bool sawError = false, sawCascade = false, sawFailedRepair = false;
+
+        foreach (var a in activities)
+        {
+            if (a.Status == ActivityStatusCode.Error) sawError = true;
+            foreach (var tag in a.TagObjects)
+            {
+                if (tag.Key == "cascade.triggered" && tag.Value is true) sawCascade = true;
+                if (tag.Key == "repair.healthy" && tag.Value is false) sawFailedRepair = true;
+            }
+        }
+
+        if (sawError || sawCascade || sawFailedRepair) return true;
+
+        // Default fallback: deterministic 25% by TraceId hash.
+        return (traceId.GetHashCode() & 0xFFFF) < 0xFFFF * SampleRatio;
+    }
+
+    private sealed class TraceBuffer
+    {
+        public readonly List<Activity> Activities = new();
+        public bool RootSeen;
+        public DateTime RootEndTime;
+    }
+}

--- a/tests/SpaceStationMonitor.Tests/TailSamplingProcessorTests.cs
+++ b/tests/SpaceStationMonitor.Tests/TailSamplingProcessorTests.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using SpaceStationMonitor.Sampling;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class TailSamplingProcessorTests : IDisposable
+{
+    private static readonly ActivitySource Source = new("TailSamplingProcessorTests");
+    private readonly ActivityListener _listener;
+
+    public TailSamplingProcessorTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "TailSamplingProcessorTests",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose() => _listener.Dispose();
+
+    [Fact]
+    public void TraceWithErrorSpan_IsKept()
+    {
+        var clock = new TestClock();
+        var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
+
+        using var root = StartRoot();
+        root.SetStatus(ActivityStatusCode.Error);
+        root.Stop();
+        processor.OnEnd(root);
+
+        clock.Advance(TimeSpan.FromMilliseconds(250));
+        processor.FlushExpired();
+
+        Assert.Equal(TailSamplingDecision.Kept, processor.GetDecision(root.TraceId));
+    }
+
+    [Fact]
+    public void TraceWithCascadeTag_IsKept()
+    {
+        var clock = new TestClock();
+        var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
+
+        using var root = StartRoot();
+        root.SetTag("cascade.triggered", true);
+        root.Stop();
+        processor.OnEnd(root);
+
+        clock.Advance(TimeSpan.FromMilliseconds(250));
+        processor.FlushExpired();
+
+        Assert.Equal(TailSamplingDecision.Kept, processor.GetDecision(root.TraceId));
+    }
+
+    [Fact]
+    public void TraceWithFailedRepairTag_IsKept()
+    {
+        var clock = new TestClock();
+        var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
+
+        using var root = StartRoot();
+        root.SetTag("repair.healthy", false);
+        root.Stop();
+        processor.OnEnd(root);
+
+        clock.Advance(TimeSpan.FromMilliseconds(250));
+        processor.FlushExpired();
+
+        Assert.Equal(TailSamplingDecision.Kept, processor.GetDecision(root.TraceId));
+    }
+
+    [Fact]
+    public void TraceWithoutTriggers_IsRatioSampled()
+    {
+        var clock = new TestClock();
+        var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
+
+        var traceIds = new ActivityTraceId[1000];
+        for (int i = 0; i < 1000; i++)
+        {
+            using var root = StartRoot();
+            // No error / cascade / failed-repair tags — falls into the 25%-by-hash bucket.
+            root.Stop();
+            processor.OnEnd(root);
+            traceIds[i] = root.TraceId;
+        }
+
+        clock.Advance(TimeSpan.FromMilliseconds(250));
+        processor.FlushExpired();
+
+        int kept = traceIds.Count(id => processor.GetDecision(id) == TailSamplingDecision.Kept);
+
+        Assert.InRange(kept, 200, 300);
+    }
+
+    [Fact]
+    public void BufferOverflow_ForcesOldestTraceDecision()
+    {
+        var clock = new TestClock();
+        var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
+
+        // Fill the buffer to exactly the cap with traces that have NOT had their root end yet —
+        // they would otherwise sit pending forever.
+        var pendingIds = new ActivityTraceId[TailSamplingProcessor.DefaultBufferCap];
+        for (int i = 0; i < TailSamplingProcessor.DefaultBufferCap; i++)
+        {
+            // Use a child-ish activity (no Stop) so RootSeen stays false on the buffer.
+            using var act = StartRoot();
+            // Don't call Stop — buffer entry exists, RootSeen flag stays false.
+            processor.OnEnd(act);
+            pendingIds[i] = act.TraceId;
+        }
+
+        // Sanity: every one of those is still Pending (no root-end recorded).
+        Assert.Equal(TailSamplingDecision.Pending, processor.GetDecision(pendingIds[0]));
+
+        // Pushing a new trace evicts the oldest and force-decides it.
+        using var nthPlusOne = StartRoot();
+        processor.OnEnd(nthPlusOne);
+
+        Assert.NotEqual(TailSamplingDecision.Pending, processor.GetDecision(pendingIds[0]));
+    }
+
+    [Fact]
+    public void RootSpanEndPlusGrace_TriggersFlush()
+    {
+        var clock = new TestClock();
+        var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
+
+        using var root = StartRoot();
+        root.Stop();
+        processor.OnEnd(root);
+
+        // Before grace window elapses, decision is still pending.
+        clock.Advance(TimeSpan.FromMilliseconds(150));
+        processor.FlushExpired();
+        Assert.Equal(TailSamplingDecision.Pending, processor.GetDecision(root.TraceId));
+
+        // After grace window elapses, decision lands.
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        processor.FlushExpired();
+        Assert.NotEqual(TailSamplingDecision.Pending, processor.GetDecision(root.TraceId));
+    }
+
+    private static Activity StartRoot()
+    {
+        var a = Source.StartActivity("Root", ActivityKind.Internal, parentContext: default);
+        Assert.NotNull(a);
+        return a!;
+    }
+
+    private sealed class TestClock
+    {
+        public DateTime Now { get; private set; } = new DateTime(2026, 4, 26, 0, 0, 0, DateTimeKind.Utc);
+        public void Advance(TimeSpan delta) => Now = Now.Add(delta);
+    }
+}

--- a/tests/SpaceStationMonitor.Tests/TailSamplingProcessorTests.cs
+++ b/tests/SpaceStationMonitor.Tests/TailSamplingProcessorTests.cs
@@ -82,7 +82,7 @@ public class TailSamplingProcessorTests : IDisposable
         for (int i = 0; i < 1000; i++)
         {
             using var root = StartRoot();
-            // No error / cascade / failed-repair tags — falls into the 25%-by-hash bucket.
+            // No error / cascade / failed-repair tags, falls into the 25%-by-hash bucket.
             root.Stop();
             processor.OnEnd(root);
             traceIds[i] = root.TraceId;
@@ -102,14 +102,13 @@ public class TailSamplingProcessorTests : IDisposable
         var clock = new TestClock();
         var processor = new TailSamplingProcessor(graceWindow: TimeSpan.FromMilliseconds(200), nowProvider: () => clock.Now);
 
-        // Fill the buffer to exactly the cap with traces that have NOT had their root end yet —
-        // they would otherwise sit pending forever.
+        // Fill the buffer to exactly the cap. RootSeen flips true on each OnEnd because
+        // StartRoot produces parentless activities, but the test clock is not advanced, so
+        // FlushExpiredLocked sees (now - RootEndTime) < graceWindow and every trace stays Pending.
         var pendingIds = new ActivityTraceId[TailSamplingProcessor.DefaultBufferCap];
         for (int i = 0; i < TailSamplingProcessor.DefaultBufferCap; i++)
         {
-            // Use a child-ish activity (no Stop) so RootSeen stays false on the buffer.
             using var act = StartRoot();
-            // Don't call Stop — buffer entry exists, RootSeen flag stays false.
             processor.OnEnd(act);
             pendingIds[i] = act.TraceId;
         }


### PR DESCRIPTION
## Summary
- New `Sampling/TailSamplingProcessor.cs` — `BaseProcessor<Activity>` that buffers activities by `TraceId`, flushes on root-span-end + 200 ms grace, and decides per the spec's four rules (Error / `cascade.triggered=true` / `repair.healthy=false` keep; everything else falls into a deterministic 25% sample by TraceId hash). Buffer cap 1000 traces, FIFO eviction on overflow.
- `Program.cs` adds `.SetExemplarFilter(ExemplarFilterType.TraceBased)` on the `MeterProviderBuilder`. OpenTelemetry SDK 1.15.1 supports the API directly, no package bump needed.
- Cheat-sheet doc gains a new "Sampling" section that distinguishes head vs tail, calls out that real production tail sampling lives in the OpenTelemetry Collector (the in-process implementation is a single-process teaching simulation), and walks the metric → trace exemplar loop on `station.repair.effectiveness`.

PR1 of Scott's bonded Sprint 003 stack — B2 (#44) opens stacked on this branch and retargets to `main` after this merges.

Closes #43.

## Test plan
- [x] `dotnet test` — 106 passed (100 baseline + 6 new tail-sampling tests, named exactly per Research AC8: `TraceWithErrorSpan_IsKept`, `TraceWithCascadeTag_IsKept`, `TraceWithFailedRepairTag_IsKept`, `TraceWithoutTriggers_IsRatioSampled` (1000 traces, 200-300 kept margin), `BufferOverflow_ForcesOldestTraceDecision`, `RootSpanEndPlusGrace_TriggersFlush`).
- [x] Smoke: `TEST_MODE=1 TEST_MAX_CYCLES=2 TEST_TICK_MS=50 dotnet run` — game runs cleanly, no exporter errors, Achievements line still renders.
- [ ] Manual smoke against Aspire: exemplars on `station.repair.effectiveness` are clickable and link to a real trace.
- [ ] B2 (#44, stacked) wires `TailSamplingProcessor` into the Hard-mode profile via `SamplerProfileFactory`; that PR will exercise the processor end-to-end through the OTel pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)