### PR TITLE
Sprint 003 UI Polish #24 + #25: hull bar + selected indicator

### DIFF
--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -32,7 +32,7 @@ public class GameDisplay
         Console.ResetColor();
     }
 
-    public void Render(Station station, HullThresholdSampler? sampler = null)
+    public void Render(Station station, int selectedSubsystem, HullThresholdSampler? sampler = null)
     {
         ClearIfInteractive();
         var hullStr = $"{station.HullIntegrity:F0}%";
@@ -41,24 +41,20 @@ public class GameDisplay
         Console.WriteLine("╔══════════════════════════════════════════════════╗");
         WritePaddedLine("          SPACE STATION MONITOR v1.0              ");
 
-        // Row 3 column budget must total InnerWidth: 10 + 16 + 7 + 9 + 8 = 50.
-        var hullColor = station.HullIntegrity < 30 ? ConsoleColor.Red : ConsoleColor.Cyan;
-        if (sampler != null)
+        var hullColor = station.HullIntegrity switch
         {
-            var stormy = sampler.CurrentRegime == SamplingRegime.Storm;
-            var badgeText = stormy ? "◉ rec" : "◌ idle";
-            var badgeColor = stormy ? ConsoleColor.Red : ConsoleColor.DarkCyan;
-            WritePaddedSegments(
-                ("          Hull Integrity: ", ConsoleColor.Cyan),
-                ($"{hullStr,-7}", hullColor),
-                ("Sampler: ", ConsoleColor.Cyan),
-                ($"{badgeText,-8}", badgeColor));
-        }
-        else
-        {
-            Console.ForegroundColor = hullColor;
-            WritePaddedLine($"          Hull Integrity: {hullStr,-24}");
-        }
+            < 15 => ConsoleColor.Red,
+            < 30 => ConsoleColor.Yellow,
+            _ => ConsoleColor.Green
+        };
+        var hullBarLength = (int)(station.HullIntegrity / 100.0 * 16);
+        var hullBar = new string('█', hullBarLength) + new string('░', 16 - hullBarLength);
+        WritePaddedSegments(
+            ("      Hull Integrity: ", ConsoleColor.Cyan),
+            (hullBar, hullColor),
+            ("  ", hullColor),
+            ($"{hullStr,-4}", hullColor),
+            ("      ", ConsoleColor.Cyan));
 
         Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("╠══════════════════════════════════════════════════╣");
@@ -67,18 +63,27 @@ public class GameDisplay
         {
             var sub = station.Subsystems[i];
             var barLength = (int)(sub.Health / 100.0 * 16);
-            var bar = new string('\u2588', barLength) + new string('\u2591', 16 - barLength);
-            var warning = sub.IsCritical ? " \u26A0" : "  ";
+            var bar = new string('█', barLength) + new string('░', 16 - barLength);
+            var warning = sub.IsCritical ? " ⚠" : "  ";
             var healthStr = $"{sub.Health:F0}%";
-
-            Console.ForegroundColor = sub.Health switch
+            var healthColor = sub.Health switch
             {
                 < 15 => ConsoleColor.Red,
                 < 30 => ConsoleColor.Yellow,
                 _ => ConsoleColor.Green
             };
 
-            WritePaddedLine($"  [{i + 1}] {sub.Name,-16} {bar}  {healthStr,-4}{warning}   ");
+            if (i == selectedSubsystem)
+            {
+                WritePaddedSegments(
+                    ("▶ ", ConsoleColor.Cyan),
+                    ($"[{i + 1}] {sub.Name,-16} {bar}  {healthStr,-4}{warning}   ", healthColor));
+            }
+            else
+            {
+                Console.ForegroundColor = healthColor;
+                WritePaddedLine($"  [{i + 1}] {sub.Name,-16} {bar}  {healthStr,-4}{warning}   ");
+            }
         }
 
         Console.ForegroundColor = ConsoleColor.Cyan;
@@ -88,19 +93,19 @@ public class GameDisplay
         if (_currentWarning != null)
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
-            WritePaddedLine($"  \u26A0 {_currentWarning}");
+            WritePaddedLine($"  ⚠ {_currentWarning}");
             hasMessage = true;
         }
         if (_currentEvent != null)
         {
             Console.ForegroundColor = ConsoleColor.Magenta;
-            WritePaddedLine($"  \u2604 {_currentEvent}");
+            WritePaddedLine($"  ☄ {_currentEvent}");
             hasMessage = true;
         }
         if (_currentAchievement != null)
         {
             Console.ForegroundColor = ConsoleColor.Cyan;
-            WritePaddedLine($"  \u2605 {_currentAchievement}");
+            WritePaddedLine($"  ★ {_currentAchievement}");
             hasMessage = true;
         }
         if (_lastRepairMessage != null)
@@ -119,7 +124,8 @@ public class GameDisplay
         Console.WriteLine("╠══════════════════════════════════════════════════╣");
         WritePaddedLine("  [1-4] Select   [R] Repair   [E] Emergency Pwr   ");
         WritePaddedLine($"  [Q] Quit   Emerg Pwr: {station.EmergencyPowerRemaining,-2} |  Repairs: {station.RepairsRemainingThisCycle,-2} left");
-        WritePaddedLine($"  Cycle: {station.CycleCount,-9}|  Score: {station.Score,-22}");
+        var selectedName = station.Subsystems[selectedSubsystem].Name;
+        WritePaddedLine($"  Cycle: {station.CycleCount,-4}|  Score: {station.Score,-7}|  Sel: {selectedName,-10}");
         Console.WriteLine("╚══════════════════════════════════════════════════╝");
         Console.ResetColor();
     }

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -64,7 +64,7 @@ public sealed class GameLoop
 
     public async Task RunAsync(CancellationToken shutdownToken)
     {
-        _display.Render(_station, _sampler);
+        _display.Render(_station, _selectedSubsystem, _sampler);
 
         try
         {
@@ -203,7 +203,7 @@ public sealed class GameLoop
                 _logger.LogInformation("Station cycle {Cycle} complete — hull integrity {Hull:F1}%",
                     _station.CycleCount, _station.HullIntegrity);
 
-                _display.Render(_station, _sampler);
+                _display.Render(_station, _selectedSubsystem, _sampler);
 
                 if (_testConfig.MaxCycles is int max && _station.CycleCount >= max) break;
             }
@@ -245,10 +245,10 @@ public sealed class GameLoop
     {
         switch (key)
         {
-            case '1': _selectedSubsystem = 0; _display.Render(_station, _sampler); break;
-            case '2': _selectedSubsystem = 1; _display.Render(_station, _sampler); break;
-            case '3': _selectedSubsystem = 2; _display.Render(_station, _sampler); break;
-            case '4': _selectedSubsystem = 3; _display.Render(_station, _sampler); break;
+            case '1': _selectedSubsystem = 0; _display.Render(_station, _selectedSubsystem, _sampler); break;
+            case '2': _selectedSubsystem = 1; _display.Render(_station, _selectedSubsystem, _sampler); break;
+            case '3': _selectedSubsystem = 2; _display.Render(_station, _selectedSubsystem, _sampler); break;
+            case '4': _selectedSubsystem = 3; _display.Render(_station, _selectedSubsystem, _sampler); break;
 
             case 'R': HandleRepair(); break;
             case 'E': HandleEmergencyPower(); break;
@@ -300,7 +300,7 @@ public sealed class GameLoop
                 new KeyValuePair<string, object?>("subsystem.name", sub.Name));
             _logger.LogInformation("Repair denied on {Name}: quota exhausted this cycle", sub.Name);
             _display.SetRepairMessage("No repairs left this cycle — wait for next tick");
-            _display.Render(_station, _sampler);
+            _display.Render(_station, _selectedSubsystem, _sampler);
             return;
         }
 
@@ -357,7 +357,7 @@ public sealed class GameLoop
 
         _display.SetRepairMessage(
             $"Repaired {sub.Name}: {currentHealth:F0}% → {expectedHealth:F0}%");
-        _display.Render(_station, _sampler);
+        _display.Render(_station, _selectedSubsystem, _sampler);
     }
 
     private void HandleEmergencyPower()
@@ -373,6 +373,6 @@ public sealed class GameLoop
         {
             _display.SetRepairMessage("No emergency power remaining!");
         }
-        _display.Render(_station, _sampler);
+        _display.Render(_station, _selectedSubsystem, _sampler);
     }
 }


### PR DESCRIPTION
## Summary

Combined UI Polish PR for Issues #24 (selected-subsystem indicator + footer Sel cell) and #25 (16-cell hull bar with corrected color thresholds), per breakdown §2.2 and UI spec §3 + §4.

### #25 — Hull-integrity 16-cell bar

- Row 3 drops the Sprint 002 sampler-badge slot. The badge goes silent until B2 #44 lands the footer N+2 cell, per breakdown §3 sequencing rationale.
- 16-cell `█`/`░` bar mirrors the subsystem-row pattern so the bars align vertically.
- Three-state hull color (Red < 15, Yellow < 30, Green otherwise) replaces the prior two-state rule. Hull thresholds now match subsystem thresholds.
- `WritePaddedSegments` render: cyan label, `hullColor` for bar + percent, cyan trailing pad. Column accounting: 6 + 16 + 16 + 2 + 4 + 6 = 50.

### #24 — Selected-subsystem ▶ indicator + footer Sel: cell

- Selected subsystem row prefixes with cyan `▶` via `WritePaddedSegments`; non-selected rows go through the existing single-color `WritePaddedLine` path. Net column accounting unchanged at 50 (the `▶ ` 2-char prefix replaces the prior `  ` 2-space leader).
- Footer row N+3 gains a `|  Sel: <Name>` cell. Cycle narrows from 9 to 4 cols, Score narrows from 22 to 7 cols, Sel takes 10 cols. Column accounting: 9 + 4 + 10 + 7 + 8 + 10 = 48 + 2 trailing = 50.
- `GameDisplay.Render` signature gains `int selectedSubsystem`; all 9 `_display.Render(...)` call sites in `GameLoop.cs` updated to pass `_selectedSubsystem`.

### Sampler parameter

The `HullThresholdSampler? sampler = null` parameter stays on `Render` so Scott's B2 #44 can repurpose it for the footer N+2 badge migration without another signature shuffle. The body no longer reads it.

## PR ordering

Lands first, before Scott's B2 #44, per breakdown §3. Removing the row-3 badge here is the precondition for B2's footer N+2 badge migration.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 100/100 green, no new tests added (visual changes; spec-optional rendering snapshot deferred)
- [ ] Manual smoke: launch the game, verify hull bar renders 16 cells with correct color at various health levels, verify ▶ moves with `1`/`2`/`3`/`4` keys, verify Sel cell updates accordingly

Closes #24, closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)