### PR TITLE
Sprint 004 #49: bump OpenTelemetry packages 1.15.1 → 1.15.3 (CVE)

### DIFF
--- a/src/SpaceStationMonitor/SpaceStationMonitor.csproj
+++ b/src/SpaceStationMonitor/SpaceStationMonitor.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Patch-level bump of the three direct OpenTelemetry package refs in `src/SpaceStationMonitor/SpaceStationMonitor.csproj` from **1.15.1 → 1.15.3** to clear three GHSA advisories. No code-shape changes; csproj edit only.

## Advisories cleared

| GHSA | Package | Patched in |
| --- | --- | --- |
| [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) | `OpenTelemetry.Api` (transitive of `OpenTelemetry`) | 1.15.3 |
| [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) | `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.15.3 |
| [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) | `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.15.2 |

1.15.3 is the floor that clears all three. Patch-level only — no SemVer-major / no minor jump.

## Why these three packages and not OTelWizard

`OTelWizard.csproj` only references `Grpc.AspNetCore` / `Google.Protobuf` / `Grpc.Tools` — no direct OTel SDK ref, so it's out of scope. `SpaceStationMonitor.Tests` inherits via `ProjectReference` to `SpaceStationMonitor`, so no separate edit is needed there.

## Verification

### Gate 1 — `dotnet list package --vulnerable --include-transitive` (solution-wide)

```
The following sources were used:
   https://api.nuget.org/v3/index.json

The given project `OTelWizard` has no vulnerable packages given the current sources.
The given project `SpaceStationMonitor` has no vulnerable packages given the current sources.
The given project `SpaceStationMonitor.Tests` has no vulnerable packages given the current sources.
```

### Gate 2 — `dotnet build` (zero NU1902)

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

### Gate 3 — `dotnet test`

```
Passed!  - Failed:     0, Passed:   109, Skipped:     0, Total:   109, Duration: 671 ms - SpaceStationMonitor.Tests.dll (net10.0)
```

### Gate 4 — Headless smoke

`TEST_MODE=1 TEST_MAX_CYCLES=8 TEST_TICK_MS=50 dotnet run --project src/SpaceStationMonitor` ran clean to `SESSION ENDED` after 8 cycles, exit 0. Final hull 67.3%, no cascade failures, 1 achievement unlocked.

## Test plan

- [x] `dotnet list package --vulnerable` clean on all three packages
- [x] `dotnet build` succeeds with zero NU1902 warnings
- [x] `dotnet test` — all 109 tests pass
- [x] `TEST_MODE` smoke run — clean run-to-exit

Closes #49