### PR TITLE
Sprint 004 D1 #53: AttributeKeyDrift bug strategy + MutateTags hook

### DIFF
--- a/docs/bug-catalog-debugging.md
+++ b/docs/bug-catalog-debugging.md
@@ -158,3 +158,17 @@ A trace can span multiple processes. Each process sees only its own slice; the t
 **Completion signal for cross-process traces.** Root-end + grace works in a single-process app because every trace's root is observable locally. A remote-parented trace never sees its true root end, so the buffer needs a different completion signal. The one this codebase ships is an inactivity timeout: when no activity has been added to a buffered trace for a configurable window, flush. Real production tail samplers in the OpenTelemetry Collector use cross-process trace assembly (and a timeout fallback) for the same reason.
 
 *Teaches: `Parent is null` is not the same as 'trace root' once W3C propagation is in play.*
+
+## Semantic conventions
+
+Attribute keys are a contract. A metric, span, or log entry tagged `subsystem.name=Oxygen` and another tagged `subsystem=Oxygen` describe the same logical thing, but to a query engine they're two different dimensions. Filter by either key and you only see half the rows. The bug compounds the longer it lives because every consumer (dashboard, alert rule, downstream pipeline) is built against whichever key they happened to see first.
+
+OpenTelemetry maintains a Semantic Conventions spec for exactly this reason: to make the contract explicit and shareable across services. Drift sneaks in through refactors, copy-paste between services, and emission code that doesn't read the existing tag conventions before adding a new tag.
+
+**Symptom:** dashboard filter by attribute shows fewer rows than expected; total row count looks correct in aggregate but key-specific filters return half.
+
+**Look at:** distinct attribute keys per metric or span over a time window. A healthy emission site has one key per logical dimension; a drifted one has two or more.
+
+**Likely cause:** the same logical dimension is emitted under inconsistent keys (e.g. `subsystem.name` vs `subsystem`) across cycles, services, or refactors.
+
+*Teaches: attribute keys are a typed contract; the time to enforce it is at the emission boundary, not after a dashboard quietly under-counts for a week.*

--- a/src/SpaceStationMonitor/BugStrategies/AttributeKeyDriftStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/AttributeKeyDriftStrategy.cs
@@ -1,0 +1,110 @@
+namespace SpaceStationMonitor.BugStrategies;
+
+/// <summary>
+/// Emits the same logical attribute under inconsistent keys across cycles. While active,
+/// odd-cycle emissions on targeted instruments rename the canonical <c>subsystem.name</c>
+/// tag to <c>subsystem</c>; even cycles pass through. The bug is invisible in the UI; it
+/// surfaces when an operator filters a metric or trace by attribute key in the dashboard
+/// and gets roughly half the rows they expect.
+///
+/// Targeted instruments are the high-frequency subsystem-keyed emission points: the
+/// <c>station.cycles.total</c> counter (in practice carries no <c>subsystem.name</c>, so
+/// the rename is a no-op there; the wiring is symmetric across all three sites), the
+/// <c>station.subsystem.health</c> observable gauge, and the <c>SubsystemTick</c> span
+/// tag set. Every variant of the <c>subsystem</c> key actually emitted is recorded in
+/// <see cref="ObservedKeys"/> so the game-over reveal can report the count.
+/// </summary>
+public sealed class AttributeKeyDriftStrategy : BugStrategyBase
+{
+    private const string CanonicalKey = "subsystem.name";
+    private const string DriftedKey = "subsystem";
+
+    private static readonly HashSet<string> TargetedInstruments = new()
+    {
+        "station.cycles.total",
+        "station.subsystem.health",
+        "SubsystemTick",
+    };
+
+    private readonly Func<int> _cycleProvider;
+    private readonly HashSet<string> _observedKeys = new();
+    private readonly object _observedKeysLock = new();
+
+    public override string Name => "AttributeKeyDrift";
+
+    /// <summary>
+    /// Distinct tag-key variants emitted on targeted instruments since activation.
+    /// Read at game-over to render the reveal. The collection returned is a snapshot;
+    /// safe to enumerate without locking even while the strategy continues mutating.
+    /// </summary>
+    public IReadOnlyCollection<string> ObservedKeys
+    {
+        get
+        {
+            lock (_observedKeysLock)
+            {
+                return _observedKeys.ToArray();
+            }
+        }
+    }
+
+    public AttributeKeyDriftStrategy(
+        string bugTarget,
+        TimeSpan? activationDelay = null,
+        Func<int>? cycleProvider = null)
+        : base(bugTarget, activationDelay)
+    {
+        _cycleProvider = cycleProvider ?? (() => 0);
+    }
+
+    public override IEnumerable<KeyValuePair<string, object?>> MutateTags(
+        string instrumentName,
+        IEnumerable<KeyValuePair<string, object?>> tags)
+    {
+        if (!IsBugActive) return tags;
+        if (!TargetedInstruments.Contains(instrumentName)) return tags;
+
+        bool drift = _cycleProvider() % 2 != 0;
+
+        if (!drift)
+        {
+            // Even cycle: pass through, but record the canonical key if this targeted
+            // instrument actually carries it. ObservedKeys must reflect every variant
+            // emitted on a targeted site, not just the drifted ones.
+            foreach (var tag in tags)
+            {
+                if (tag.Key == CanonicalKey)
+                {
+                    RecordKey(CanonicalKey);
+                    break;
+                }
+            }
+            return tags;
+        }
+
+        // Odd cycle: rename the canonical key on this targeted instrument and record the
+        // drifted variant. Other tags are passed through unchanged.
+        var result = new List<KeyValuePair<string, object?>>();
+        foreach (var tag in tags)
+        {
+            if (tag.Key == CanonicalKey)
+            {
+                result.Add(new KeyValuePair<string, object?>(DriftedKey, tag.Value));
+                RecordKey(DriftedKey);
+            }
+            else
+            {
+                result.Add(tag);
+            }
+        }
+        return result;
+    }
+
+    private void RecordKey(string key)
+    {
+        lock (_observedKeysLock)
+        {
+            _observedKeys.Add(key);
+        }
+    }
+}

--- a/src/SpaceStationMonitor/BugStrategies/AttributeKeyDriftStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/AttributeKeyDriftStrategy.cs
@@ -7,12 +7,11 @@ namespace SpaceStationMonitor.BugStrategies;
 /// surfaces when an operator filters a metric or trace by attribute key in the dashboard
 /// and gets roughly half the rows they expect.
 ///
-/// Targeted instruments are the high-frequency subsystem-keyed emission points: the
-/// <c>station.cycles.total</c> counter (in practice carries no <c>subsystem.name</c>, so
-/// the rename is a no-op there; the wiring is symmetric across all three sites), the
-/// <c>station.subsystem.health</c> observable gauge, and the <c>SubsystemTick</c> span
-/// tag set. Every variant of the <c>subsystem</c> key actually emitted is recorded in
-/// <see cref="ObservedKeys"/> so the game-over reveal can report the count.
+/// Targeted instruments are the two subsystem-keyed emission points that actually carry
+/// a <c>subsystem.name</c> tag: the <c>station.subsystem.health</c> observable gauge and
+/// the <c>SubsystemTick</c> span tag set. Every variant of the <c>subsystem</c> key
+/// actually emitted is recorded in <see cref="ObservedKeys"/> so the game-over reveal
+/// can report the count.
 /// </summary>
 public sealed class AttributeKeyDriftStrategy : BugStrategyBase
 {
@@ -21,7 +20,6 @@ public sealed class AttributeKeyDriftStrategy : BugStrategyBase
 
     private static readonly HashSet<string> TargetedInstruments = new()
     {
-        "station.cycles.total",
         "station.subsystem.health",
         "SubsystemTick",
     };

--- a/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
+++ b/src/SpaceStationMonitor/BugStrategies/BugStrategyCatalog.cs
@@ -19,6 +19,7 @@ public static class BugStrategyCatalog
         new RetryStormStrategy(bugTarget, activationDelay),
         new SamplingBlindSpotStrategy(bugTarget, activationDelay),
         new OrphanSpanStrategy(bugTarget, activationDelay, cycleProvider),
+        new AttributeKeyDriftStrategy(bugTarget, activationDelay, cycleProvider),
     ];
 
     public static IBugStrategy? FindByName(IEnumerable<IBugStrategy> strategies, string name)

--- a/src/SpaceStationMonitor/BugStrategies/IBugStrategy.cs
+++ b/src/SpaceStationMonitor/BugStrategies/IBugStrategy.cs
@@ -26,6 +26,17 @@ public interface IBugStrategy
     /// untouched (default behavior).
     /// </summary>
     ActivityContext? OverrideStationCycleParent();
+
+    /// <summary>
+    /// Optional hook letting a strategy mutate the tag set emitted at a high-frequency
+    /// instrument site. The default returns <paramref name="tags"/> unchanged. Strategies
+    /// that simulate semantic-convention drift (renaming, dropping, or adding keys) override
+    /// this; <paramref name="instrumentName"/> lets the strategy scope its mutation to
+    /// specific targets.
+    /// </summary>
+    IEnumerable<KeyValuePair<string, object?>> MutateTags(
+        string instrumentName,
+        IEnumerable<KeyValuePair<string, object?>> tags);
 }
 
 public abstract class BugStrategyBase : IBugStrategy
@@ -50,4 +61,8 @@ public abstract class BugStrategyBase : IBugStrategy
     public virtual Subsystem RedirectDegradationTarget(Subsystem requested, IReadOnlyList<Subsystem> all) => requested;
     public virtual TimeSpan? RepairDelay(Subsystem sub) => null;
     public virtual ActivityContext? OverrideStationCycleParent() => null;
+
+    public virtual IEnumerable<KeyValuePair<string, object?>> MutateTags(
+        string instrumentName,
+        IEnumerable<KeyValuePair<string, object?>> tags) => tags;
 }

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -132,11 +132,16 @@ public sealed class GameLoop
 
                     _station.DegradeSubsystem(actualTarget);
 
-                    tickActivity?.SetTag("subsystem.name", actualTarget.Name);
-                    tickActivity?.SetTag("health.before", Math.Round(healthBefore, 1));
-                    tickActivity?.SetTag("health.after", Math.Round(actualTarget.Health, 1));
-                    tickActivity?.SetTag("degradation.rate",
-                        Math.Round(actualTarget.BaseDegradationRate * actualTarget.CascadeMultiplier, 2));
+                    var tickTags = new KeyValuePair<string, object?>[]
+                    {
+                        new("subsystem.name", actualTarget.Name),
+                        new("health.before", Math.Round(healthBefore, 1)),
+                        new("health.after", Math.Round(actualTarget.Health, 1)),
+                        new("degradation.rate",
+                            Math.Round(actualTarget.BaseDegradationRate * actualTarget.CascadeMultiplier, 2)),
+                    };
+                    foreach (var tag in _strategy.MutateTags("SubsystemTick", tickTags))
+                        tickActivity?.SetTag(tag.Key, tag.Value);
 
                     _logger.LogInformation("Subsystem {Name}: {Before:F1}% → {After:F1}%",
                         actualTarget.Name, healthBefore, actualTarget.Health);
@@ -202,7 +207,10 @@ public sealed class GameLoop
                     _display.SetEvent(null);
                 }
 
-                Telemetry.CyclesTotal.Add(_strategy.CycleCounterIncrement());
+                var cyclesTags = _strategy
+                    .MutateTags("station.cycles.total", Array.Empty<KeyValuePair<string, object?>>())
+                    .ToArray();
+                Telemetry.CyclesTotal.Add(_strategy.CycleCounterIncrement(), cyclesTags);
                 _station.EndCycle();
                 _achievementSystem?.CheckAndFire(_station, cycleActivity, _logger, _display);
                 cycleActivity?.SetTag("hull.integrity", Math.Round(_station.HullIntegrity, 1));

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -207,10 +207,7 @@ public sealed class GameLoop
                     _display.SetEvent(null);
                 }
 
-                var cyclesTags = _strategy
-                    .MutateTags("station.cycles.total", Array.Empty<KeyValuePair<string, object?>>())
-                    .ToArray();
-                Telemetry.CyclesTotal.Add(_strategy.CycleCounterIncrement(), cyclesTags);
+                Telemetry.CyclesTotal.Add(_strategy.CycleCounterIncrement());
                 _station.EndCycle();
                 _achievementSystem?.CheckAndFire(_station, cycleActivity, _logger, _display);
                 cycleActivity?.SetTag("hull.integrity", Math.Round(_station.HullIntegrity, 1));

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -222,8 +222,11 @@ if (samplerProfileEnvIgnored)
 // ── Register gauge metrics (need Station reference) ─────────────────────────
 Telemetry.Meter.CreateObservableGauge("station.subsystem.health",
     () => station.Subsystems.Select(s =>
-        new Measurement<double>(s.Health,
-            new KeyValuePair<string, object?>("subsystem.name", s.Name))),
+    {
+        var rawTags = new[] { new KeyValuePair<string, object?>("subsystem.name", s.Name) };
+        var mutated = strategy.MutateTags("station.subsystem.health", rawTags).ToArray();
+        return new Measurement<double>(s.Health, mutated);
+    }),
     "percent", "Current health of each subsystem");
 
 Telemetry.Meter.CreateObservableGauge<double>("station.hull.integrity",
@@ -275,6 +278,10 @@ if (gameMode == GameMode.Learning)
     if (repairSystem.Strategy is OrphanSpanStrategy orphan && orphan.InjectedCount > 0)
     {
         Console.WriteLine($"  Telemetry root-detection: {orphan.InjectedCount} synthetic remote-parented cycles");
+    }
+    if (repairSystem.Strategy is AttributeKeyDriftStrategy drift && drift.ObservedKeys.Count > 1)
+    {
+        Console.WriteLine($"  Telemetry attribute keys observed: {drift.ObservedKeys.Count} variants on 'subsystem'");
     }
 }
 Console.ResetColor();

--- a/tests/SpaceStationMonitor.Tests/AttributeKeyDriftStrategyTests.cs
+++ b/tests/SpaceStationMonitor.Tests/AttributeKeyDriftStrategyTests.cs
@@ -1,0 +1,134 @@
+using SpaceStationMonitor.BugStrategies;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class AttributeKeyDriftStrategyTests
+{
+    private const string Target = "Oxygen";
+
+    private static AttributeKeyDriftStrategy Active(int cycle) => new(
+        Target, activationDelay: TimeSpan.Zero, cycleProvider: () => cycle);
+
+    private static AttributeKeyDriftStrategy Inactive(int cycle) => new(
+        Target, activationDelay: TimeSpan.MaxValue, cycleProvider: () => cycle);
+
+    private static KeyValuePair<string, object?>[] CanonicalSubsystemTags(string name) =>
+        new[] { new KeyValuePair<string, object?>("subsystem.name", name) };
+
+    [Fact]
+    public void MutateTags_OnOddCycle_RenamesSubsystemName()
+    {
+        var strategy = Active(cycle: 1);
+
+        var result = strategy
+            .MutateTags("SubsystemTick", CanonicalSubsystemTags("Oxygen"))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal("subsystem", result[0].Key);
+        Assert.Equal("Oxygen", result[0].Value);
+    }
+
+    [Fact]
+    public void MutateTags_OnEvenCycle_IsPassthrough()
+    {
+        var strategy = Active(cycle: 2);
+
+        var result = strategy
+            .MutateTags("SubsystemTick", CanonicalSubsystemTags("Power"))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal("subsystem.name", result[0].Key);
+        Assert.Equal("Power", result[0].Value);
+    }
+
+    [Fact]
+    public void MutateTags_OnUntargetedInstrument_IsPassthrough()
+    {
+        // Odd cycle would normally drift, but this instrument is not in the targeted set.
+        var strategy = Active(cycle: 1);
+
+        var result = strategy
+            .MutateTags("station.repairs.total", CanonicalSubsystemTags("Shields"))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal("subsystem.name", result[0].Key);
+        Assert.Equal("Shields", result[0].Value);
+    }
+
+    [Fact]
+    public void MutateTags_BeforeActivation_IsPassthrough()
+    {
+        // Even on a cycle that would drift, IsBugActive=false short-circuits.
+        var strategy = Inactive(cycle: 1);
+
+        var result = strategy
+            .MutateTags("SubsystemTick", CanonicalSubsystemTags("Thermal"))
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal("subsystem.name", result[0].Key);
+        Assert.Equal("Thermal", result[0].Value);
+    }
+
+    [Fact]
+    public void ObservedKeys_AfterMixedCycles_TracksBothVariants()
+    {
+        int cycle = 0;
+        var strategy = new AttributeKeyDriftStrategy(
+            Target, activationDelay: TimeSpan.Zero, cycleProvider: () => cycle);
+
+        for (cycle = 1; cycle <= 6; cycle++)
+        {
+            // Drain the enumerable so RecordKey runs on pass-through cycles too.
+            foreach (var _ in strategy.MutateTags("SubsystemTick", CanonicalSubsystemTags("Oxygen")))
+            {
+                // intentionally empty
+            }
+        }
+
+        var keys = strategy.ObservedKeys;
+        Assert.Equal(2, keys.Count);
+        Assert.Contains("subsystem.name", keys);
+        Assert.Contains("subsystem", keys);
+    }
+
+    [Fact]
+    public void ObservedKeys_BeforeActivation_StaysEmpty()
+    {
+        int cycle = 0;
+        var strategy = new AttributeKeyDriftStrategy(
+            Target, activationDelay: TimeSpan.MaxValue, cycleProvider: () => cycle);
+
+        for (cycle = 1; cycle <= 6; cycle++)
+        {
+            foreach (var _ in strategy.MutateTags("SubsystemTick", CanonicalSubsystemTags("Oxygen")))
+            {
+                // intentionally empty
+            }
+        }
+
+        Assert.Empty(strategy.ObservedKeys);
+    }
+
+    [Fact]
+    public void ObservedKeys_OnUntargetedInstrument_NotPopulated()
+    {
+        int cycle = 0;
+        var strategy = new AttributeKeyDriftStrategy(
+            Target, activationDelay: TimeSpan.Zero, cycleProvider: () => cycle);
+
+        for (cycle = 1; cycle <= 6; cycle++)
+        {
+            foreach (var _ in strategy.MutateTags("station.repairs.total", CanonicalSubsystemTags("Oxygen")))
+            {
+                // intentionally empty
+            }
+        }
+
+        Assert.Empty(strategy.ObservedKeys);
+    }
+}


### PR DESCRIPTION
## Why this change

This adds a hidden `AttributeKeyDrift` bug strategy that teaches players to recognize attribute-key drift through telemetry. While active, hot-path metrics emit the same logical dimension under two inconsistent keys (`subsystem.name` and `subsystem`), which would split a metric series across inconsistent dimensions in production and leave dashboard filters returning ~50% of expected rows. The post-game reveal counts the variants observed so the lesson lands explicitly after the run.

## Impact if not merged

Sprint 004 stretch slot stays unfilled; the bug strategy doesn't ship. No regression risk, no functional cost beyond the missed teaching beat.

## Technical detail

### Summary

- Adds `AttributeKeyDriftStrategy`, a bug strategy that emits `subsystem.name` under two inconsistent keys (`subsystem.name` vs `subsystem`) across cycles. Invisible in the UI; surfaces in dashboard filters as a ~50/50 row split.
- Adds a new `MutateTags(instrumentName, tags)` hook on `IBugStrategy` with a pass-through default in `BugStrategyBase`. The eight existing strategies inherit the default unchanged (AC2).
- Wires `MutateTags` at the two high-frequency emission sites that actually carry a `subsystem.name` tag (AC4): the `SubsystemTick` span tag set and the `station.subsystem.health` observable gauge callback. Other emission sites untouched.
- Game-over reveal placed inside the existing Learning-mode block in `Program.cs`, next to the OrphanSpan reveal (AC10).
- New "Semantic conventions" section in `docs/bug-catalog-debugging.md` (AC6).
- 7 new unit tests covering MutateTags branches and ObservedKeys behaviour (AC7 + AC11).

### Drop-cleanly contract

Per the spec's atomicity clause, this PR ships the full surface as one unit:

- `MutateTags` hook on `IBugStrategy` interface
- Default pass-through in `BugStrategyBase`
- New `AttributeKeyDriftStrategy.cs`
- Catalog registration
- 2 mutate-tags call sites (SubsystemTick + ObservableGauge)
- Game-over reveal gated on `is AttributeKeyDriftStrategy && ObservedKeys.Count > 1`
- Cheat-sheet "Semantic conventions" section
- All D1 tests

`grep` for `MutateTags|AttributeKeyDriftStrategy|repairSystem.Strategy is AttributeKeyDriftStrategy` returns 26 hits across exactly the 6 expected files at the current head.

### Cycle-provider pattern

Mirrors `OrphanSpanStrategy` exactly: `Func<int>? cycleProvider = null` constructor parameter with default `() => 0`, plumbed through `BugStrategyCatalog.All` from the existing `Program.cs:105` lambda `() => station.CycleCount + 1`.

### Test plan

- [x] 7 new D1 unit tests in `AttributeKeyDriftStrategyTests.cs` (AC7 + AC11): MutateTags on odd/even/untargeted/inactive cycles + ObservedKeys after-mixed/before-activation/untargeted.
- [x] Full suite green: 189/189 tests pass (182 baseline + 7 D1 tests).
- [x] Solution builds clean (0 warnings, 0 errors).
- [x] Headless smoke: `TEST_MODE=1 BUG_STRATEGY=AttributeKeyDrift BUG_ACTIVATION_DELAY_MS=0 OTEL_TEST_CAPTURE=1` selected the strategy, ran past activation, and the game-over reveal fired with the spec-mandated format: `Telemetry attribute keys observed: 2 variants on 'subsystem'`.
- [ ] Manual Aspire dashboard smoke (filter `station.subsystem.health` by `subsystem.name=Oxygen` then `subsystem=Oxygen`, observe ~50/50 split). Recommended at QA's sprint-end pass.

### Notes

- `RepairSystem.Strategy` was already public on merged main (`RepairSystem.cs:16`), so the game-over reveal needed zero exposure work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
