### PR TITLE
Sprint 004 B3: Concurrent repairs + cascade-tick span links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,14 +63,19 @@ Don't unify these unintentionally — SpaceStationMonitor was bumped to 10 delib
 
 - **tests/SpaceStationMonitor.Tests/** - Unit tests for Station, RepairSystem, and CascadeEngine.
 
-**Span hierarchy per cycle:**
+**Span topology:**
 ```
-StationCycle (root)
+StationCycle (root, one per cycle)
 ├── SubsystemTick × 4      (one per subsystem, with health.before/after tags)
-├── RepairAction           (only on player repair; span events on leak/failure)
-├── CascadeCheck           (when any subsystem is critical)
+├── CascadeCheck × N       (when any subsystem is critical; links to source SubsystemTick)
 └── StationEvent           (on random events)
+
+RepairAction (root, lives 1-3 cycles after press)
+  ↑ each StationCycle while in-flight links to this Activity
+    (cycle → repair causality without parent-of falsification)
 ```
+
+`RepairAction` is started when a slot is claimed (`HandleRepair` → `RepairSystem.BeginRepair`) and stops on completion, player cancel, reject, or shutdown. It is a root span, never parented to `StationCycle` — every in-flight cycle emits an `ActivityLink` to its context. `CascadeCheck` is parented to `StationCycle` (same cycle) but adds an `ActivityLink` to its source `SubsystemTick` since the cascade is causally-from-but-not-a-child-of the tick.
 
 - **Service name:** `SpaceStationMonitor`
 - **Traces:** `StationCycle` (parent span per cycle), `SubsystemTick` (per subsystem), `RepairAction`, `CascadeCheck`, `StationEvent`

--- a/src/SpaceStationMonitor/ActiveRepairs.cs
+++ b/src/SpaceStationMonitor/ActiveRepairs.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+
+namespace SpaceStationMonitor;
+
+public sealed record InFlightRepair(
+    Subsystem Subsystem,
+    int Requested,
+    int CyclesRemaining,
+    Activity? RepairAction);
+
+public sealed class ActiveRepairs
+{
+    private readonly int _maxConcurrentRepairs;
+    private readonly List<InFlightRepair> _entries = new();
+
+    public ActiveRepairs(int concurrentRepairs)
+    {
+        _maxConcurrentRepairs = concurrentRepairs;
+    }
+
+    public int InFlightCount => _entries.Count;
+    public int AvailableSlots => _maxConcurrentRepairs - _entries.Count;
+    public IReadOnlyList<InFlightRepair> InFlight => _entries;
+
+    // A repair starts only if a slot is free AND the subsystem isn't already under repair.
+    // The same-subsystem block prevents stacking two hands on one repair, which would let
+    // a player cheat the cycles-required commitment by re-pressing R every tick.
+    public bool TryStart(InFlightRepair entry)
+    {
+        if (_entries.Count >= _maxConcurrentRepairs) return false;
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            if (ReferenceEquals(_entries[i].Subsystem, entry.Subsystem)) return false;
+        }
+        _entries.Add(entry);
+        return true;
+    }
+
+    public void DecrementAll()
+    {
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            var e = _entries[i];
+            _entries[i] = e with { CyclesRemaining = e.CyclesRemaining - 1 };
+        }
+    }
+
+    public IReadOnlyList<InFlightRepair> DrainCompleted()
+    {
+        var completed = new List<InFlightRepair>();
+        for (int i = _entries.Count - 1; i >= 0; i--)
+        {
+            if (_entries[i].CyclesRemaining <= 0)
+            {
+                completed.Insert(0, _entries[i]);
+                _entries.RemoveAt(i);
+            }
+        }
+        return completed;
+    }
+
+    public bool TryCancelOldestOn(Subsystem target, out InFlightRepair? cancelled)
+    {
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            if (ReferenceEquals(_entries[i].Subsystem, target))
+            {
+                cancelled = _entries[i];
+                _entries.RemoveAt(i);
+                return true;
+            }
+        }
+        cancelled = null;
+        return false;
+    }
+}

--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -156,15 +156,14 @@ public class GameDisplay
 
         Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("╠══════════════════════════════════════════════════╣");
-        WritePaddedLine("  [1-4] Select   [R] Repair   [E] Emergency Pwr   ");
+        WritePaddedLine("  [1-4] Select [R] Repair [C] Cancel [E] Emerg Pwr");
         RenderFooterCounters(station, indicator);
-        var selectedName = station.Subsystems[selectedSubsystem].Name;
-        WritePaddedLine($"  Cycle: {station.CycleCount,-4}|  Score: {station.Score,-7}|  Sel: {selectedName,-10}");
+        RenderHandsRow(station);
         Console.WriteLine("╚══════════════════════════════════════════════════╝");
         Console.ResetColor();
     }
 
-    // Footer column budget: 19 + 2 + 11 + 2 + 7 + 8 = 49 (+1 trailing pad) = 50.
+    // Footer column budget: 19 + 2 + 8 + 2 + 9 + 8 = 48 (+2 trailing pad) = 50.
     // Badge color is regime-dependent; everything else is frame Cyan.
     private static void RenderFooterCounters(Station station, SampleRegimeIndicator? indicator)
     {
@@ -172,10 +171,26 @@ public class GameDisplay
         WritePaddedSegments(
             ("  [Q] Quit  Emerg: ", ConsoleColor.Cyan),
             ($"{station.EmergencyPowerRemaining,-2}", ConsoleColor.Cyan),
-            ("  Repairs: ", ConsoleColor.Cyan),
-            ($"{station.RepairsRemainingThisCycle,-2}", ConsoleColor.Cyan),
-            ("  Smp: ", ConsoleColor.Cyan),
+            ("  Free: ", ConsoleColor.Cyan),
+            ($"{station.ActiveRepairs.AvailableSlots,-2}", ConsoleColor.Cyan),
+            ("    Smp: ", ConsoleColor.Cyan),
             ($"{badgeText,-8}", badgeColor));
+    }
+
+    // Yellow at saturation gives a glance-at-cell affordance: the player can tell
+    // whether pressing R will succeed without parsing the n/cap numbers.
+    private static void RenderHandsRow(Station station)
+    {
+        var inFlight = station.ActiveRepairs.InFlightCount;
+        var capacity = inFlight + station.ActiveRepairs.AvailableSlots;
+        var handsColor = inFlight >= capacity ? ConsoleColor.Yellow : ConsoleColor.White;
+        WritePaddedSegments(
+            ("  Cycle: ", ConsoleColor.Cyan),
+            ($"{station.CycleCount,-4}", ConsoleColor.White),
+            ("|  Score: ", ConsoleColor.Cyan),
+            ($"{station.Score,-7}", ConsoleColor.White),
+            ("|  Hands: ", ConsoleColor.Cyan),
+            ($"{inFlight}/{capacity}", handsColor));
     }
 
     // Splash picker row: "  [N] {modeName}" with mode label colored, padded to 50 cols.

--- a/src/SpaceStationMonitor/GameDisplay.cs
+++ b/src/SpaceStationMonitor/GameDisplay.cs
@@ -163,7 +163,7 @@ public class GameDisplay
         Console.ResetColor();
     }
 
-    // Footer column budget: 19 + 2 + 8 + 2 + 9 + 8 = 48 (+2 trailing pad) = 50.
+    // Footer column budget: 19 + 2 + 9 + 8 = 38 (+12 trailing pad) = 50.
     // Badge color is regime-dependent; everything else is frame Cyan.
     private static void RenderFooterCounters(Station station, SampleRegimeIndicator? indicator)
     {
@@ -171,8 +171,6 @@ public class GameDisplay
         WritePaddedSegments(
             ("  [Q] Quit  Emerg: ", ConsoleColor.Cyan),
             ($"{station.EmergencyPowerRemaining,-2}", ConsoleColor.Cyan),
-            ("  Free: ", ConsoleColor.Cyan),
-            ($"{station.ActiveRepairs.AvailableSlots,-2}", ConsoleColor.Cyan),
             ("    Smp: ", ConsoleColor.Cyan),
             ($"{badgeText,-8}", badgeColor));
     }

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -111,6 +111,17 @@ public sealed class GameLoop
                 }
 
                 var parentOverride = _strategy.OverrideStationCycleParent() ?? default;
+
+                // Build the link list from in-flight repairs before StartActivity. Each
+                // in-flight RepairAction Activity gets linked from the new StationCycle so
+                // the trace tree carries "this cycle relates to that in-flight repair."
+                var inFlightLinks = new List<ActivityLink>();
+                foreach (var inFlight in _station.ActiveRepairs.InFlight)
+                {
+                    if (inFlight.RepairAction is { Context: { } ctx } && ctx != default)
+                        inFlightLinks.Add(new ActivityLink(ctx));
+                }
+
                 using var cycleActivity = Telemetry.ActivitySource.StartActivity(
                     "StationCycle",
                     ActivityKind.Internal,
@@ -120,9 +131,46 @@ public sealed class GameLoop
                         new("bug.strategy", _strategy.Name),
                         new("bug.active", isBugActive),
                         new("cycle.number", _station.CycleCount + 1),
-                    });
+                    },
+                    links: inFlightLinks);
 
                 _station.StartNewCycle(isBugActive);
+
+                // Drain in-flight repairs: tick down remaining cycles, complete any that
+                // hit zero. CompleteRepair stops the saved RepairAction Activity, applies
+                // health, and emits the histogram + log.
+                _station.ActiveRepairs.DecrementAll();
+                foreach (var completed in _station.ActiveRepairs.DrainCompleted())
+                {
+                    var result = _repairSystem.CompleteRepair(completed);
+
+                    double effectiveness = result.Requested > 0
+                        ? (double)result.Applied / result.Requested * 100.0
+                        : 0;
+                    Telemetry.RepairEffectiveness.Record(effectiveness,
+                        new KeyValuePair<string, object?>("subsystem.name", result.SubsystemName));
+                    _station.RecordRepair(effectiveness);
+
+                    if (!result.IsHealthy)
+                    {
+                        _logger.LogError("Repair leak on {Name}: requested {Requested}% applied {Applied}%",
+                            result.SubsystemName, result.Requested, result.Applied);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Repair applied to {Name}: {Before:F1}% → {After:F1}%",
+                            result.SubsystemName, result.HealthBefore, result.HealthAfter);
+                    }
+
+                    _display.SetRepairMessage(
+                        $"{result.SubsystemName} repair complete: {result.HealthBefore:F0}% → {result.DisplayedAfter:F0}%");
+                }
+
+                // Tick activities are saved per-subsystem so the cascade loop can link a
+                // cascade back to the tick that triggered it. Keyed by sub.Name (what the
+                // cascade engine asks for via cascade.SourceSubsystem), not the redirected
+                // actualTarget — under WrongTargetDegradationStrategy the two diverge.
+                var tickActivities = new Dictionary<string, Activity?>();
 
                 foreach (var sub in _station.Subsystems)
                 {
@@ -143,6 +191,8 @@ public sealed class GameLoop
                     foreach (var tag in _strategy.MutateTags("SubsystemTick", tickTags))
                         tickActivity?.SetTag(tag.Key, tag.Value);
 
+                    tickActivities[sub.Name] = tickActivity;
+
                     _logger.LogInformation("Subsystem {Name}: {Before:F1}% → {After:F1}%",
                         actualTarget.Name, healthBefore, actualTarget.Health);
                 }
@@ -157,6 +207,18 @@ public sealed class GameLoop
                 foreach (var cascade in cascades)
                 {
                     using var cascadeActivity = Telemetry.ActivitySource.StartActivity("CascadeCheck");
+
+                    // Link cascade to the source-tick activity that triggered it. Parent-of
+                    // would be wrong (the cascade isn't a child of the tick); a link carries
+                    // the causal relationship without falsifying parentage.
+                    if (cascadeActivity is not null
+                        && tickActivities.TryGetValue(cascade.SourceSubsystem, out var sourceTick)
+                        && sourceTick is not null
+                        && sourceTick.Context != default)
+                    {
+                        cascadeActivity.AddLink(new ActivityLink(sourceTick.Context));
+                    }
+
                     cascadeActivity?.SetTag("cascade.triggered", true);
                     cascadeActivity?.SetTag("source.subsystem", cascade.SourceSubsystem);
                     cascadeActivity?.SetTag("affected.subsystems",
@@ -263,6 +325,7 @@ public sealed class GameLoop
             case '4': _selectedSubsystem = 3; _display.Render(_station, _selectedSubsystem, _indicator); break;
 
             case 'R': HandleRepair(); break;
+            case 'C': HandleCancelRepair(); break;
             case 'E': HandleEmergencyPower(); break;
 
             case 'Q':
@@ -305,69 +368,63 @@ public sealed class GameLoop
     {
         var sub = _station.Subsystems[_selectedSubsystem];
 
-        if (!_station.TryConsumeRepair())
+        if (sub.Health >= 100)
         {
-            Telemetry.RepairsDenied.Add(1,
-                new KeyValuePair<string, object?>("subsystem.name", sub.Name));
-            _logger.LogInformation("Repair denied on {Name}: quota exhausted this cycle", sub.Name);
-            _display.SetRepairMessage("No repairs left this cycle — wait for next tick");
+            _display.SetRepairMessage($"{sub.Name} is at full health.");
             _display.Render(_station, _selectedSubsystem, _indicator);
             return;
         }
 
         var requested = _repairSystem.GetRepairAmount();
-        var currentHealth = sub.Health;
-        var expectedHealth = Math.Min(100, currentHealth + requested);
+        var entry = _repairSystem.BeginRepair(sub, requested);
 
-        using var repairActivity = Telemetry.ActivitySource.StartActivity("RepairAction");
-
-        try
+        if (!_station.ActiveRepairs.TryStart(entry))
         {
-            var result = _repairSystem.Repair(sub, requested, _station.TryConsumeRepair);
+            // BeginRepair already started a RepairAction Activity; on rejection the
+            // unbacked Activity must be stopped immediately so it doesn't leak across
+            // cycles. The reject-Activity carries requested+cycles_required tags but
+            // never reaches CompleteRepair — that is the correct shape for "we tried,
+            // no slot was free, no repair occurred."
+            entry.RepairAction?.SetStatus(ActivityStatusCode.Error, "rejected");
+            entry.RepairAction?.Stop();
 
-            repairActivity?.SetTag("subsystem.name", result.SubsystemName);
-            repairActivity?.SetTag("repair.requested", result.Requested);
-            repairActivity?.SetTag("repair.applied", result.Applied);
-            repairActivity?.SetTag("repair.healthy", result.IsHealthy);
-
-            double effectiveness = result.Requested > 0
-                ? (double)result.Applied / result.Requested * 100.0
-                : 0;
-            Telemetry.RepairEffectiveness.Record(effectiveness,
-                new KeyValuePair<string, object?>("subsystem.name", result.SubsystemName));
-            _station.RecordRepair(effectiveness);
-
-            if (!result.IsHealthy)
-            {
-                repairActivity?.AddEvent(new ActivityEvent("RepairLeak",
-                    tags: new ActivityTagsCollection
-                    {
-                        { "repair.delta", result.Requested - result.Applied }
-                    }));
-
-                _logger.LogError("Repair leak on {Name}: requested {Requested}% applied {Applied}%",
-                    result.SubsystemName, result.Requested, result.Applied);
-            }
-            else
-            {
-                _logger.LogInformation("Repair applied to {Name}: {Before:F1}% → {After:F1}%",
-                    result.SubsystemName, result.HealthBefore, result.HealthAfter);
-            }
-
-            expectedHealth = result.DisplayedAfter;
-        }
-        catch (Exception ex)
-        {
-            repairActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            repairActivity?.AddException(ex);
-            repairActivity?.AddEvent(new ActivityEvent("RepairFailed"));
-
-            _logger.LogError(ex, "Repair failed on {Name}: requested {Requested}%",
-                sub.Name, requested);
+            Telemetry.RepairsDenied.Add(1,
+                new KeyValuePair<string, object?>("subsystem.name", sub.Name));
+            _logger.LogInformation("Repair denied on {Name}: all hands busy", sub.Name);
+            _display.SetRepairMessage("All hands busy.");
+            _display.Render(_station, _selectedSubsystem, _indicator);
+            return;
         }
 
-        _display.SetRepairMessage(
-            $"Repaired {sub.Name}: {currentHealth:F0}% → {expectedHealth:F0}%");
+        _logger.LogInformation("Repair started on {Name}: {Requested}% over {Cycles} cycle(s)",
+            sub.Name, requested, entry.CyclesRemaining);
+        _display.SetRepairMessage($"Started repair on {sub.Name}.");
+        _display.Render(_station, _selectedSubsystem, _indicator);
+    }
+
+    private void HandleCancelRepair()
+    {
+        var sub = _station.Subsystems[_selectedSubsystem];
+        if (_station.ActiveRepairs.TryCancelOldestOn(sub, out var cancelled) && cancelled is not null)
+        {
+            cancelled.RepairAction?.AddEvent(new ActivityEvent("RepairCancelled",
+                tags: new ActivityTagsCollection
+                {
+                    { "cancellation.reason", "player_cancel" }
+                }));
+            cancelled.RepairAction?.SetStatus(ActivityStatusCode.Error, "cancelled");
+            cancelled.RepairAction?.Stop();
+
+            Telemetry.RepairsFailed.Add(1,
+                new KeyValuePair<string, object?>("subsystem.name", sub.Name),
+                new KeyValuePair<string, object?>("cancellation.reason", "player_cancel"));
+
+            _display.SetRepairMessage($"Cancelled repair on {sub.Name}.");
+        }
+        else
+        {
+            _display.SetRepairMessage($"Nothing to cancel on {sub.Name}.");
+        }
         _display.Render(_station, _selectedSubsystem, _indicator);
     }
 

--- a/src/SpaceStationMonitor/GameLoop.cs
+++ b/src/SpaceStationMonitor/GameLoop.cs
@@ -286,6 +286,22 @@ public sealed class GameLoop
         {
             // Normal shutdown via Ctrl+C
         }
+        finally
+        {
+            // Stop any RepairAction Activities still in flight when the loop exits
+            // (Ctrl+C, hull-zero game-over, max-cycles cap). Without this, those
+            // Activities never get Stop()ed and surface as orphan spans in the trace
+            // export. cancellation.reason="shutdown" keeps the queryable dimension
+            // symmetric with the player-cancel path.
+            foreach (var entry in _station.ActiveRepairs.InFlight)
+            {
+                entry.RepairAction?.SetStatus(ActivityStatusCode.Error, "shutdown");
+                entry.RepairAction?.Stop();
+                Telemetry.RepairsFailed.Add(1,
+                    new KeyValuePair<string, object?>("subsystem.name", entry.Subsystem.Name),
+                    new KeyValuePair<string, object?>("cancellation.reason", "shutdown"));
+            }
+        }
     }
 
     private async Task PollInputAsync(CancellationTokenSource waitCts)
@@ -402,7 +418,7 @@ public sealed class GameLoop
         _display.Render(_station, _selectedSubsystem, _indicator);
     }
 
-    private void HandleCancelRepair()
+    internal void HandleCancelRepair()
     {
         var sub = _station.Subsystems[_selectedSubsystem];
         if (_station.ActiveRepairs.TryCancelOldestOn(sub, out var cancelled) && cancelled is not null)

--- a/src/SpaceStationMonitor/Program.cs
+++ b/src/SpaceStationMonitor/Program.cs
@@ -57,7 +57,7 @@ else
 
 // ── Per-mode + per-difficulty configuration ─────────────────────────────────
 var tuning = DifficultyTunings.For(difficulty);
-int repairsPerCycle = tuning.RepairsPerCycle;
+int concurrentRepairs = tuning.RepairsPerCycle;
 double degradationMultiplier = tuning.DegradationMultiplier;
 double eventChanceMultiplier = tuning.EventChanceMultiplier;
 
@@ -84,7 +84,7 @@ else
 // ── Game components ─────────────────────────────────────────────────────────
 // Clocks (Station.StartTime, strategy start time) capture DateTime.UtcNow at
 // construction, so these must be built AFTER the splash blocks for input.
-var station = new Station(repairsPerCycle, degradationMultiplier);
+var station = new Station(concurrentRepairs, degradationMultiplier);
 var random = new Random();
 var subsystemNames = station.Subsystems.Select(s => s.Name).ToArray();
 

--- a/src/SpaceStationMonitor/RepairSystem.cs
+++ b/src/SpaceStationMonitor/RepairSystem.cs
@@ -32,16 +32,25 @@ public class RepairSystem
 
         // StartActivity inherits Activity.Current as parent even when an explicit
         // parentContext: default is supplied; null'ing Current first is the only
-        // reliable way to force the new Activity to be a true root span.
+        // reliable way to force the new Activity to be a true root span. The
+        // restore lives in finally so a throw from StartActivity or any SetTag
+        // can't leak the null Current into the caller's ambient context.
         var previousCurrent = Activity.Current;
         Activity.Current = null;
-        var activity = Telemetry.ActivitySource.StartActivity(
-            "RepairAction",
-            ActivityKind.Internal);
-        activity?.SetTag("subsystem.name", subsystem.Name);
-        activity?.SetTag("repair.requested", requested);
-        activity?.SetTag("repair.cycles_required", cyclesRequired);
-        Activity.Current = previousCurrent;
+        Activity? activity;
+        try
+        {
+            activity = Telemetry.ActivitySource.StartActivity(
+                "RepairAction",
+                ActivityKind.Internal);
+            activity?.SetTag("subsystem.name", subsystem.Name);
+            activity?.SetTag("repair.requested", requested);
+            activity?.SetTag("repair.cycles_required", cyclesRequired);
+        }
+        finally
+        {
+            Activity.Current = previousCurrent;
+        }
 
         return new InFlightRepair(subsystem, requested, cyclesRequired, activity);
     }

--- a/src/SpaceStationMonitor/RepairSystem.cs
+++ b/src/SpaceStationMonitor/RepairSystem.cs
@@ -18,9 +18,64 @@ public class RepairSystem
     public bool IsBugActive => _strategy.IsBugActive;
     public string BugStrategyName => _strategy.Name;
 
+    // BeginRepair starts a RepairAction Activity at slot-claim time and returns the
+    // in-flight entry. The Activity stays open across cycle boundaries; CompleteRepair
+    // (or the cancellation path) is responsible for stopping it.
+    public InFlightRepair BeginRepair(Subsystem subsystem, int requested)
+    {
+        int cyclesRequired = Math.Clamp((int)Math.Ceiling((100 - subsystem.Health) / 33.0), 1, 3);
+
+        var activity = Telemetry.ActivitySource.StartActivity(
+            "RepairAction",
+            ActivityKind.Internal);
+        activity?.SetTag("subsystem.name", subsystem.Name);
+        activity?.SetTag("repair.requested", requested);
+        activity?.SetTag("repair.cycles_required", cyclesRequired);
+
+        return new InFlightRepair(subsystem, requested, cyclesRequired, activity);
+    }
+
+    public RepairResult CompleteRepair(InFlightRepair entry)
+    {
+        var activity = entry.RepairAction;
+        try
+        {
+            var result = Repair(entry.Subsystem, entry.Requested, tryConsumeQuota: null);
+            activity?.SetTag("repair.applied", result.Applied);
+            activity?.SetTag("repair.healthy", result.IsHealthy);
+            if (!result.IsHealthy)
+            {
+                activity?.AddEvent(new ActivityEvent("RepairLeak",
+                    tags: new ActivityTagsCollection
+                    {
+                        { "repair.delta", result.Requested - result.Applied }
+                    }));
+            }
+            return result;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.AddException(ex);
+            activity?.AddEvent(new ActivityEvent("RepairFailed"));
+            return new RepairResult(
+                SubsystemName: entry.Subsystem.Name,
+                Requested: entry.Requested,
+                Applied: 0,
+                HealthBefore: entry.Subsystem.Health,
+                HealthAfter: entry.Subsystem.Health,
+                DisplayedAfter: entry.Subsystem.Health,
+                IsHealthy: false);
+        }
+        finally
+        {
+            activity?.Stop();
+        }
+    }
+
     // tryConsumeQuota is called before each RETRY (not the original attempt, which
-    // is gated upstream by HandleRepair). When it returns false the retry loop
-    // bails with repairs.denied++ and the caught exception propagates.
+    // is gated upstream). When it returns false the retry loop bails with repairs.denied++
+    // and the caught exception propagates.
     public RepairResult Repair(Subsystem subsystem, int requested, Func<bool>? tryConsumeQuota = null)
     {
         var delay = _strategy.RepairDelay(subsystem);

--- a/src/SpaceStationMonitor/RepairSystem.cs
+++ b/src/SpaceStationMonitor/RepairSystem.cs
@@ -20,17 +20,28 @@ public class RepairSystem
 
     // BeginRepair starts a RepairAction Activity at slot-claim time and returns the
     // in-flight entry. The Activity stays open across cycle boundaries; CompleteRepair
-    // (or the cancellation path) is responsible for stopping it.
+    // (or the cancellation / shutdown path) is responsible for stopping it. RepairAction
+    // is a ROOT span (parentContext: default) and Activity.Current is restored after the
+    // Start so the in-flight Activity does not pollute the ambient context — otherwise
+    // the next StationCycle would inherit RepairAction as its parent, inverting the
+    // researcher AC-16 invariant that StationCycle is the cycle root and RepairAction
+    // is linked-from-StationCycle, never parented-to-StationCycle.
     public InFlightRepair BeginRepair(Subsystem subsystem, int requested)
     {
         int cyclesRequired = Math.Clamp((int)Math.Ceiling((100 - subsystem.Health) / 33.0), 1, 3);
 
+        // StartActivity inherits Activity.Current as parent even when an explicit
+        // parentContext: default is supplied; null'ing Current first is the only
+        // reliable way to force the new Activity to be a true root span.
+        var previousCurrent = Activity.Current;
+        Activity.Current = null;
         var activity = Telemetry.ActivitySource.StartActivity(
             "RepairAction",
             ActivityKind.Internal);
         activity?.SetTag("subsystem.name", subsystem.Name);
         activity?.SetTag("repair.requested", requested);
         activity?.SetTag("repair.cycles_required", cyclesRequired);
+        Activity.Current = previousCurrent;
 
         return new InFlightRepair(subsystem, requested, cyclesRequired, activity);
     }
@@ -58,6 +69,13 @@ public class RepairSystem
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.AddException(ex);
             activity?.AddEvent(new ActivityEvent("RepairFailed"));
+            // Counter rides with the RepairFailed event so unexpected exceptions
+            // (NRE, OOM, lifecycle) don't drop silently. Repair's inner catch already
+            // increments on its own !ShouldRetryAfterFailure / quota-denied paths;
+            // re-throws from there land here too, which is acceptable counter
+            // duplication for the symmetric event-and-counter shape.
+            Telemetry.RepairsFailed.Add(1,
+                new KeyValuePair<string, object?>("subsystem.name", entry.Subsystem.Name));
             return new RepairResult(
                 SubsystemName: entry.Subsystem.Name,
                 Requested: entry.Requested,

--- a/src/SpaceStationMonitor/RepairSystem.cs
+++ b/src/SpaceStationMonitor/RepairSystem.cs
@@ -72,10 +72,12 @@ public class RepairSystem
             // Counter rides with the RepairFailed event so unexpected exceptions
             // (NRE, OOM, lifecycle) don't drop silently. Repair's inner catch already
             // increments on its own !ShouldRetryAfterFailure / quota-denied paths;
-            // re-throws from there land here too, which is acceptable counter
-            // duplication for the symmetric event-and-counter shape.
+            // re-throws from there land here too, producing 2x on common-bail paths.
+            // failure.layer="outer" tags this site so dashboards can dedupe via
+            // `RepairsFailed{failure.layer != "outer"}` for unique-attempt counts.
             Telemetry.RepairsFailed.Add(1,
-                new KeyValuePair<string, object?>("subsystem.name", entry.Subsystem.Name));
+                new KeyValuePair<string, object?>("subsystem.name", entry.Subsystem.Name),
+                new KeyValuePair<string, object?>("failure.layer", "outer"));
             return new RepairResult(
                 SubsystemName: entry.Subsystem.Name,
                 Requested: entry.Requested,

--- a/src/SpaceStationMonitor/Station.cs
+++ b/src/SpaceStationMonitor/Station.cs
@@ -25,17 +25,17 @@ public class Subsystem
 public class Station
 {
     private readonly Random _random = new();
-    private readonly int _repairsPerCycle;
     private readonly double _baseDegradationMultiplier;
     private double _difficultyMultiplier = 1.0;
     private int _postBugCycles;
 
-    public Station(int repairsPerCycle = 3, double degradationMultiplier = 1.0)
+    public Station(int concurrentRepairs = 3, double degradationMultiplier = 1.0)
     {
-        _repairsPerCycle = repairsPerCycle;
         _baseDegradationMultiplier = degradationMultiplier;
-        RepairsRemainingThisCycle = repairsPerCycle;
+        ActiveRepairs = new ActiveRepairs(concurrentRepairs);
     }
+
+    public ActiveRepairs ActiveRepairs { get; }
 
     public Subsystem[] Subsystems { get; } =
     [
@@ -46,7 +46,6 @@ public class Station
     ];
 
     public int EmergencyPowerRemaining { get; private set; } = 3;
-    public int RepairsRemainingThisCycle { get; private set; }
     public int CycleCount { get; private set; }
     public DateTime StartTime { get; } = DateTime.UtcNow;
 
@@ -68,7 +67,6 @@ public class Station
     public void StartNewCycle(bool isBugActive)
     {
         CycleCount++;
-        RepairsRemainingThisCycle = _repairsPerCycle;
         SolarFlareThisCycle = false;
 
         if (EmergencyPowerRemaining == 0)
@@ -108,13 +106,6 @@ public class Station
         else IronHullStreak = 0;
 
         MinSubsystemStayedAbove30 = Subsystems.All(s => s.Health >= 30);
-    }
-
-    public bool TryConsumeRepair()
-    {
-        if (RepairsRemainingThisCycle <= 0) return false;
-        RepairsRemainingThisCycle--;
-        return true;
     }
 
     public void DegradeSubsystem(Subsystem subsystem)

--- a/src/SpaceStationMonitor/Telemetry.cs
+++ b/src/SpaceStationMonitor/Telemetry.cs
@@ -21,7 +21,7 @@ public static class Telemetry
 
     public static readonly Counter<long> RepairsDenied =
         Meter.CreateCounter<long>("station.repairs.denied",
-            description: "Repair attempts blocked by no free repair slot");
+            description: "Repair attempts blocked by no free repair slot or retry-quota exhaustion");
 
     public static readonly Counter<long> CascadeFailures =
         Meter.CreateCounter<long>("station.cascade.failures", description: "Cascade failure events");

--- a/src/SpaceStationMonitor/Telemetry.cs
+++ b/src/SpaceStationMonitor/Telemetry.cs
@@ -21,7 +21,7 @@ public static class Telemetry
 
     public static readonly Counter<long> RepairsDenied =
         Meter.CreateCounter<long>("station.repairs.denied",
-            description: "Repair attempts blocked by no free repair slot or retry-quota exhaustion");
+            description: "Repair attempts blocked by no free repair slot, repair already in flight on subsystem, or retry-quota exhaustion");
 
     public static readonly Counter<long> CascadeFailures =
         Meter.CreateCounter<long>("station.cascade.failures", description: "Cascade failure events");

--- a/src/SpaceStationMonitor/Telemetry.cs
+++ b/src/SpaceStationMonitor/Telemetry.cs
@@ -21,7 +21,7 @@ public static class Telemetry
 
     public static readonly Counter<long> RepairsDenied =
         Meter.CreateCounter<long>("station.repairs.denied",
-            description: "Repair attempts blocked by per-cycle quota");
+            description: "Repair attempts blocked by no free repair slot");
 
     public static readonly Counter<long> CascadeFailures =
         Meter.CreateCounter<long>("station.cascade.failures", description: "Cascade failure events");

--- a/tests/SpaceStationMonitor.Tests/ActiveRepairsTests.cs
+++ b/tests/SpaceStationMonitor.Tests/ActiveRepairsTests.cs
@@ -1,0 +1,134 @@
+using SpaceStationMonitor;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+public class ActiveRepairsTests
+{
+    private static InFlightRepair MakeEntry(Subsystem sub, int cycles)
+        => new(sub, Requested: 20, CyclesRemaining: cycles, RepairAction: null);
+
+    private static Subsystem NewSub(string name = "Oxygen") => new(name, 1.0);
+
+    [Fact]
+    public void TryStart_BelowCapacity_Succeeds()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        var s1 = NewSub("Oxygen");
+        var s2 = NewSub("Power");
+
+        Assert.True(ar.TryStart(MakeEntry(s1, 1)));
+        Assert.True(ar.TryStart(MakeEntry(s2, 2)));
+        Assert.Equal(2, ar.InFlightCount);
+        Assert.Equal(2, ar.AvailableSlots);
+    }
+
+    [Fact]
+    public void TryStart_AtCapacity_ReturnsFalse()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 2);
+        Assert.True(ar.TryStart(MakeEntry(NewSub("Oxygen"), 1)));
+        Assert.True(ar.TryStart(MakeEntry(NewSub("Power"), 1)));
+
+        Assert.False(ar.TryStart(MakeEntry(NewSub("Shields"), 1)));
+        Assert.Equal(2, ar.InFlightCount);
+        Assert.Equal(0, ar.AvailableSlots);
+    }
+
+    [Fact]
+    public void TryStart_SameSubsystemTwice_RejectsSecond()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        var oxygen = NewSub("Oxygen");
+
+        Assert.True(ar.TryStart(MakeEntry(oxygen, 2)));
+        // Second start on the same subsystem is rejected even though slots remain free.
+        Assert.False(ar.TryStart(MakeEntry(oxygen, 1)));
+        Assert.Equal(1, ar.InFlightCount);
+        Assert.Equal(3, ar.AvailableSlots);
+    }
+
+    [Fact]
+    public void AvailableSlots_TracksInFlightCountInverse()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        Assert.Equal(4, ar.AvailableSlots);
+
+        ar.TryStart(MakeEntry(NewSub("Oxygen"), 1));
+        ar.TryStart(MakeEntry(NewSub("Power"), 1));
+        Assert.Equal(2, ar.InFlightCount);
+        Assert.Equal(2, ar.AvailableSlots);
+
+        ar.DecrementAll();
+        ar.DrainCompleted();
+        Assert.Equal(0, ar.InFlightCount);
+        Assert.Equal(4, ar.AvailableSlots);
+    }
+
+    [Fact]
+    public void DecrementAll_DecrementsEachEntry()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        ar.TryStart(MakeEntry(NewSub("Oxygen"), 3));
+        ar.TryStart(MakeEntry(NewSub("Power"), 2));
+
+        ar.DecrementAll();
+
+        Assert.Equal(2, ar.InFlight[0].CyclesRemaining);
+        Assert.Equal(1, ar.InFlight[1].CyclesRemaining);
+    }
+
+    [Fact]
+    public void DrainCompleted_RemovesAndReturnsZeroCyclesRemaining()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        ar.TryStart(MakeEntry(NewSub("Oxygen"), 1));
+        ar.TryStart(MakeEntry(NewSub("Power"), 2));
+        ar.TryStart(MakeEntry(NewSub("Shields"), 1));
+
+        ar.DecrementAll();
+
+        var completed = ar.DrainCompleted();
+
+        Assert.Equal(2, completed.Count);
+        Assert.Contains(completed, e => e.Subsystem.Name == "Oxygen");
+        Assert.Contains(completed, e => e.Subsystem.Name == "Shields");
+        Assert.Equal(1, ar.InFlightCount);
+        Assert.Equal("Power", ar.InFlight[0].Subsystem.Name);
+    }
+
+    [Fact]
+    public void TryCancelOldestOn_OnMatchingSubsystem_RemovesOldest()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        var oxygen = NewSub("Oxygen");
+        var power = NewSub("Power");
+        var oldOxygen = MakeEntry(oxygen, 1);
+
+        ar.TryStart(oldOxygen);
+        ar.TryStart(MakeEntry(power, 1));
+
+        var ok = ar.TryCancelOldestOn(oxygen, out var cancelled);
+
+        Assert.True(ok);
+        Assert.NotNull(cancelled);
+        Assert.Same(oldOxygen.Subsystem, cancelled!.Subsystem);
+        Assert.Equal(1, ar.InFlightCount);
+        Assert.Equal("Power", ar.InFlight[0].Subsystem.Name);
+    }
+
+    [Fact]
+    public void TryCancelOldestOn_NoMatch_ReturnsFalse()
+    {
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        var oxygen = NewSub("Oxygen");
+        var power = NewSub("Power");
+        ar.TryStart(MakeEntry(oxygen, 1));
+
+        var ok = ar.TryCancelOldestOn(power, out var cancelled);
+
+        Assert.False(ok);
+        Assert.Null(cancelled);
+        Assert.Equal(1, ar.InFlightCount);
+    }
+}

--- a/tests/SpaceStationMonitor.Tests/ActivityListenerCollection.cs
+++ b/tests/SpaceStationMonitor.Tests/ActivityListenerCollection.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+// .NET ActivitySource sampling is OR'd across all registered listeners (any-says-yes
+// wins), so a parallel test's AllData listener would invalidate another test's None
+// decision. Serialising the listener-bound tests is the only reliable fix without
+// exposing internals.
+[CollectionDefinition("ActivityListener-bound", DisableParallelization = true)]
+public class ActivityListenerCollection
+{
+}

--- a/tests/SpaceStationMonitor.Tests/GameLoopAsyncRepairTests.cs
+++ b/tests/SpaceStationMonitor.Tests/GameLoopAsyncRepairTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging.Abstractions;
 using SpaceStationMonitor;
 using SpaceStationMonitor.BugStrategies;
@@ -90,7 +91,7 @@ public class GameLoopAsyncRepairTests
     }
 
     [Fact]
-    public void CancelledRepair_SetsErrorStatus_AndEmitsRepairCancelledEvent()
+    public void HandleCancelRepair_DrivesProductionPath_EmitsExpectedTelemetry()
     {
         using var listener = new ActivityListener
         {
@@ -99,33 +100,93 @@ public class GameLoopAsyncRepairTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        var strategy = new NoOpBugStrategy("Oxygen");
-        var repair = new RepairSystem(strategy);
-        var ar = new ActiveRepairs(concurrentRepairs: 4);
-        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
-        var entry = repair.BeginRepair(sub, requested: 20);
-        ar.TryStart(entry);
-
-        var ok = ar.TryCancelOldestOn(sub, out var cancelled);
-        Assert.True(ok);
-        Assert.NotNull(cancelled);
-
-        cancelled!.RepairAction?.AddEvent(new ActivityEvent("RepairCancelled",
-            tags: new ActivityTagsCollection
+        long repairsFailedCount = 0;
+        string? capturedSubsystem = null;
+        string? capturedReason = null;
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
             {
-                { "cancellation.reason", "player_cancel" }
-            }));
-        cancelled.RepairAction?.SetStatus(ActivityStatusCode.Error, "cancelled");
-        cancelled.RepairAction?.Stop();
+                if (instrument.Meter.Name == Telemetry.MeterName
+                    && instrument.Name == "station.repairs.failed")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((inst, measurement, tags, state) =>
+        {
+            Interlocked.Add(ref repairsFailedCount, measurement);
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "subsystem.name") capturedSubsystem = tag.Value as string;
+                else if (tag.Key == "cancellation.reason") capturedReason = tag.Value as string;
+            }
+        });
+        meterListener.Start();
 
-        Assert.Equal(ActivityStatusCode.Error, cancelled.RepairAction!.Status);
-        Assert.Equal("cancelled", cancelled.RepairAction.StatusDescription);
-        Assert.True(cancelled.RepairAction.Duration > TimeSpan.Zero);
+        var (loop, station, _) = BuildLoop(maxCycles: 1);
+        var sub = station.Subsystems[0];
+        sub.Health = 50;
+        var entry = new RepairSystem(new NoOpBugStrategy("Oxygen")).BeginRepair(sub, requested: 20);
+        Assert.True(station.ActiveRepairs.TryStart(entry));
 
-        var cancelEvent = cancelled.RepairAction.Events.FirstOrDefault(e => e.Name == "RepairCancelled");
+        // Drive the production HandleCancelRepair path so any regression in the
+        // AddEvent / SetStatus / Stop / Telemetry.RepairsFailed.Add chain surfaces
+        // through this test. Replaying those calls inline (the prior test shape)
+        // verified the assertion targets but not the production code path.
+        loop.HandleCancelRepair();
+
+        Assert.NotNull(entry.RepairAction);
+        Assert.Equal(ActivityStatusCode.Error, entry.RepairAction!.Status);
+        Assert.Equal("cancelled", entry.RepairAction.StatusDescription);
+        Assert.True(entry.RepairAction.Duration > TimeSpan.Zero);
+
+        var cancelEvent = entry.RepairAction.Events.FirstOrDefault(e => e.Name == "RepairCancelled");
         Assert.NotEqual(default, cancelEvent);
         var reason = cancelEvent.Tags.FirstOrDefault(t => t.Key == "cancellation.reason").Value;
         Assert.Equal("player_cancel", reason);
+
+        Assert.Equal(0, station.ActiveRepairs.InFlightCount);
+
+        meterListener.RecordObservableInstruments();
+        Assert.Equal(1, repairsFailedCount);
+        Assert.Equal("Oxygen", capturedSubsystem);
+        Assert.Equal("player_cancel", capturedReason);
+    }
+
+    [Fact]
+    public void HandleCancelRepair_NoInFlightOnSelected_NoTelemetryEmitted()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        long repairsFailedCount = 0;
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == Telemetry.MeterName
+                    && instrument.Name == "station.repairs.failed")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((inst, measurement, tags, state) =>
+            Interlocked.Add(ref repairsFailedCount, measurement));
+        meterListener.Start();
+
+        var (loop, station, _) = BuildLoop(maxCycles: 1);
+        Assert.Equal(0, station.ActiveRepairs.InFlightCount);
+
+        loop.HandleCancelRepair();
+
+        Assert.Equal(0, repairsFailedCount);
     }
 
     private static (GameLoop loop, Station station, IBugStrategy strategy) BuildLoop(int maxCycles = 3)

--- a/tests/SpaceStationMonitor.Tests/GameLoopAsyncRepairTests.cs
+++ b/tests/SpaceStationMonitor.Tests/GameLoopAsyncRepairTests.cs
@@ -116,12 +116,19 @@ public class GameLoopAsyncRepairTests
         };
         meterListener.SetMeasurementEventCallback<long>((inst, measurement, tags, state) =>
         {
-            Interlocked.Add(ref repairsFailedCount, measurement);
+            // Filter by subsystem.name + cancellation.reason so unrelated parallel
+            // tests emitting station.repairs.failed can't poison this assertion.
+            string? subsystemTag = null;
+            string? reasonTag = null;
             foreach (var tag in tags)
             {
-                if (tag.Key == "subsystem.name") capturedSubsystem = tag.Value as string;
-                else if (tag.Key == "cancellation.reason") capturedReason = tag.Value as string;
+                if (tag.Key == "subsystem.name") subsystemTag = tag.Value as string;
+                else if (tag.Key == "cancellation.reason") reasonTag = tag.Value as string;
             }
+            if (subsystemTag != "Oxygen" || reasonTag != "player_cancel") return;
+            Interlocked.Add(ref repairsFailedCount, measurement);
+            capturedSubsystem = subsystemTag;
+            capturedReason = reasonTag;
         });
         meterListener.Start();
 
@@ -178,7 +185,19 @@ public class GameLoopAsyncRepairTests
             }
         };
         meterListener.SetMeasurementEventCallback<long>((inst, measurement, tags, state) =>
-            Interlocked.Add(ref repairsFailedCount, measurement));
+        {
+            // Filter by subsystem.name so unrelated parallel tests emitting
+            // station.repairs.failed for other subsystems can't poison the
+            // == 0 assertion below.
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "subsystem.name" && (tag.Value as string) == "Oxygen")
+                {
+                    Interlocked.Add(ref repairsFailedCount, measurement);
+                    return;
+                }
+            }
+        });
         meterListener.Start();
 
         var (loop, station, _) = BuildLoop(maxCycles: 1);

--- a/tests/SpaceStationMonitor.Tests/GameLoopAsyncRepairTests.cs
+++ b/tests/SpaceStationMonitor.Tests/GameLoopAsyncRepairTests.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using SpaceStationMonitor;
+using SpaceStationMonitor.BugStrategies;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+[Collection("ActivityListener-bound")]
+public class GameLoopAsyncRepairTests
+{
+    [Fact]
+    public async Task InFlightRepair_CompletesAfterRolledCycles()
+    {
+        var (loop, station, strategy) = BuildLoop(maxCycles: 1);
+        var sub = station.Subsystems[0];
+        sub.Health = 50;
+        var entry = new InFlightRepair(sub, Requested: 20, CyclesRemaining: 1, RepairAction: null);
+        station.ActiveRepairs.TryStart(entry);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        Assert.Equal(0, station.ActiveRepairs.InFlightCount);
+        Assert.True(sub.Health > 60,
+            $"expected health bumped above 60 after repair (50 + 20 - some degradation), got {sub.Health}");
+        _ = strategy;
+    }
+
+    [Fact]
+    public async Task InFlightRepair_AddsLinkToStationCycle()
+    {
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => captured.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var testRoot = Telemetry.ActivitySource.StartActivity("TestRoot_InFlightLink");
+        Assert.NotNull(testRoot);
+
+        var (loop, station, strategy) = BuildLoop(maxCycles: 2);
+        var sub = station.Subsystems[0];
+        sub.Health = 50;
+        var inFlightActivity = Telemetry.ActivitySource.StartActivity("RepairAction");
+        Assert.NotNull(inFlightActivity);
+        var entry = new InFlightRepair(sub, Requested: 20, CyclesRemaining: 5, RepairAction: inFlightActivity);
+        station.ActiveRepairs.TryStart(entry);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        var inScope = captured.Where(a => a.TraceId == testRoot!.TraceId).ToList();
+        var cycleSpans = inScope.Where(a => a.OperationName == "StationCycle").ToList();
+        Assert.NotEmpty(cycleSpans);
+        Assert.Contains(cycleSpans, s => s.Links.Any(l => l.Context == inFlightActivity!.Context));
+
+        inFlightActivity!.Stop();
+        _ = strategy;
+    }
+
+    [Fact]
+    public async Task CompletedRepair_StopsActivity_WithFinalTags()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var (loop, station, _) = BuildLoop(maxCycles: 1);
+        var sub = station.Subsystems[0];
+        sub.Health = 50;
+        var repairActivity = Telemetry.ActivitySource.StartActivity("RepairAction");
+        Assert.NotNull(repairActivity);
+        var entry = new InFlightRepair(sub, Requested: 20, CyclesRemaining: 1, RepairAction: repairActivity);
+        station.ActiveRepairs.TryStart(entry);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        Assert.True(repairActivity!.Duration > TimeSpan.Zero);
+        var tags = repairActivity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Contains("repair.applied", tags.Keys);
+        Assert.Contains("repair.healthy", tags.Keys);
+    }
+
+    [Fact]
+    public void CancelledRepair_SetsErrorStatus_AndEmitsRepairCancelledEvent()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repair = new RepairSystem(strategy);
+        var ar = new ActiveRepairs(concurrentRepairs: 4);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
+        var entry = repair.BeginRepair(sub, requested: 20);
+        ar.TryStart(entry);
+
+        var ok = ar.TryCancelOldestOn(sub, out var cancelled);
+        Assert.True(ok);
+        Assert.NotNull(cancelled);
+
+        cancelled!.RepairAction?.AddEvent(new ActivityEvent("RepairCancelled",
+            tags: new ActivityTagsCollection
+            {
+                { "cancellation.reason", "player_cancel" }
+            }));
+        cancelled.RepairAction?.SetStatus(ActivityStatusCode.Error, "cancelled");
+        cancelled.RepairAction?.Stop();
+
+        Assert.Equal(ActivityStatusCode.Error, cancelled.RepairAction!.Status);
+        Assert.Equal("cancelled", cancelled.RepairAction.StatusDescription);
+        Assert.True(cancelled.RepairAction.Duration > TimeSpan.Zero);
+
+        var cancelEvent = cancelled.RepairAction.Events.FirstOrDefault(e => e.Name == "RepairCancelled");
+        Assert.NotEqual(default, cancelEvent);
+        var reason = cancelEvent.Tags.FirstOrDefault(t => t.Key == "cancellation.reason").Value;
+        Assert.Equal("player_cancel", reason);
+    }
+
+    private static (GameLoop loop, Station station, IBugStrategy strategy) BuildLoop(int maxCycles = 3)
+    {
+        var station = new Station();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repairSystem = new RepairSystem(strategy);
+        var eventEngine = new EventEngine(eventChanceMultiplier: 0.0);
+        var cascadeEngine = new CascadeEngine(strategy);
+        var display = new GameDisplay();
+        var random = new Random(42);
+        var config = new TestModeConfig(TestMode: true, MaxCycles: maxCycles, TickInterval: TimeSpan.FromMilliseconds(10));
+
+        var loop = new GameLoop(station, repairSystem, eventEngine, cascadeEngine,
+            display, random, NullLogger.Instance, strategy, config);
+        return (loop, station, strategy);
+    }
+}

--- a/tests/SpaceStationMonitor.Tests/GameLoopCascadeLinkTests.cs
+++ b/tests/SpaceStationMonitor.Tests/GameLoopCascadeLinkTests.cs
@@ -1,0 +1,171 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using SpaceStationMonitor;
+using SpaceStationMonitor.BugStrategies;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+[Collection("ActivityListener-bound")]
+public class GameLoopCascadeLinkTests
+{
+    [Fact]
+    public async Task CascadeCheck_LinksToSourceSubsystemTick()
+    {
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => captured.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // Wrap the cycle in a unique parent so we can scope captured activities to this
+        // test's trace and ignore activities from parallel test runs.
+        using var testRoot = Telemetry.ActivitySource.StartActivity("TestRoot_CascadeLink");
+        Assert.NotNull(testRoot);
+
+        var (loop, station) = BuildLoop(maxCycles: 1);
+        station.Subsystems[0].Health = 10;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        var inScope = captured.Where(a => a.TraceId == testRoot!.TraceId).ToList();
+        var cascadeSpans = inScope.Where(a => a.OperationName == "CascadeCheck").ToList();
+        Assert.NotEmpty(cascadeSpans);
+
+        var tickSpansBySub = inScope
+            .Where(a => a.OperationName == "SubsystemTick")
+            .GroupBy(a => a.GetTagItem("subsystem.name") as string ?? "")
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        bool atLeastOneLinked = false;
+        foreach (var cascade in cascadeSpans)
+        {
+            var source = cascade.GetTagItem("source.subsystem") as string;
+            Assert.NotNull(source);
+            if (tickSpansBySub.TryGetValue(source!, out var sourceTicks))
+            {
+                if (cascade.Links.Any(l => sourceTicks.Any(t => t.Context == l.Context)))
+                    atLeastOneLinked = true;
+            }
+        }
+        Assert.True(atLeastOneLinked, "expected at least one CascadeCheck linked to its source SubsystemTick");
+    }
+
+    [Fact]
+    public async Task CascadeCheck_LinksToSourceSubsystemTick_UnderWrongTargetDegradation()
+    {
+        // Drive the divergent path where sub.Name != actualTarget.Name. Under
+        // WrongTargetDegradationStrategy with target=Oxygen, the Oxygen tick gets
+        // redirected to Power. The dict must be keyed by sub.Name so the cascade
+        // engine's lookup of cascade.SourceSubsystem ("Oxygen") finds Oxygen's tick.
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => captured.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var testRoot = Telemetry.ActivitySource.StartActivity("TestRoot_WrongTarget");
+        Assert.NotNull(testRoot);
+
+        var strategy = new WrongTargetDegradationStrategy("Oxygen", TimeSpan.Zero);
+        // BugStrategyBase activation predicate is strict-greater-than; sleep so any
+        // positive elapsed time clears the threshold deterministically.
+        while (!strategy.IsBugActive)
+            Thread.Sleep(2);
+        Assert.True(strategy.IsBugActive);
+
+        var station = new Station();
+        var repairSystem = new RepairSystem(strategy);
+        var eventEngine = new EventEngine(eventChanceMultiplier: 0.0);
+        var cascadeEngine = new CascadeEngine(strategy);
+        var display = new GameDisplay();
+        var random = new Random(42);
+        var config = new TestModeConfig(TestMode: true, MaxCycles: 1, TickInterval: TimeSpan.FromMilliseconds(10));
+
+        var loop = new GameLoop(station, repairSystem, eventEngine, cascadeEngine,
+            display, random, NullLogger.Instance, strategy, config);
+
+        // Force a cascade on Oxygen (the source of the redirected tick).
+        station.Subsystems[0].Health = 10;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        var inScope = captured.Where(a => a.TraceId == testRoot!.TraceId).ToList();
+        var cascadeSpans = inScope.Where(a => a.OperationName == "CascadeCheck").ToList();
+        Assert.NotEmpty(cascadeSpans);
+
+        var oxygenSourcedCascades = cascadeSpans
+            .Where(c => (c.GetTagItem("source.subsystem") as string) == "Oxygen")
+            .ToList();
+        Assert.NotEmpty(oxygenSourcedCascades);
+
+        // Oxygen's tick activity has subsystem.name="Power" because of the redirect's
+        // tag set. After the dict-key fix, tickActivities["Oxygen"] still points at
+        // that Power-tagged tick — so the link binds.
+        var redirectedTicks = inScope
+            .Where(a => a.OperationName == "SubsystemTick"
+                && (a.GetTagItem("subsystem.name") as string) == "Power")
+            .ToList();
+        Assert.NotEmpty(redirectedTicks);
+
+        bool linked = oxygenSourcedCascades.Any(c =>
+            c.Links.Any(l => redirectedTicks.Any(t => t.Context == l.Context)));
+        Assert.True(linked,
+            "expected the Oxygen-sourced CascadeCheck to link back to the redirected SubsystemTick");
+    }
+
+    [Fact]
+    public async Task CascadeCheck_WhenSourceTickSampledOut_HasNoLink()
+    {
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
+                options.Name == "SubsystemTick"
+                    ? ActivitySamplingResult.None
+                    : ActivitySamplingResult.AllData,
+            ActivityStopped = a => captured.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var testRoot = Telemetry.ActivitySource.StartActivity("TestRoot_CascadeNoLink");
+        Assert.NotNull(testRoot);
+
+        var (loop, station) = BuildLoop(maxCycles: 1);
+        station.Subsystems[0].Health = 10;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await loop.RunAsync(cts.Token);
+
+        var inScope = captured.Where(a => a.TraceId == testRoot!.TraceId).ToList();
+        var cascadeSpans = inScope.Where(a => a.OperationName == "CascadeCheck").ToList();
+        Assert.NotEmpty(cascadeSpans);
+        foreach (var cascade in cascadeSpans)
+            Assert.Empty(cascade.Links);
+    }
+
+    private static (GameLoop loop, Station station) BuildLoop(int maxCycles = 1)
+    {
+        var station = new Station();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repairSystem = new RepairSystem(strategy);
+        var eventEngine = new EventEngine(eventChanceMultiplier: 0.0);
+        var cascadeEngine = new CascadeEngine(strategy);
+        var display = new GameDisplay();
+        var random = new Random(42);
+        var config = new TestModeConfig(TestMode: true, MaxCycles: maxCycles, TickInterval: TimeSpan.FromMilliseconds(10));
+
+        var loop = new GameLoop(station, repairSystem, eventEngine, cascadeEngine,
+            display, random, NullLogger.Instance, strategy, config);
+        return (loop, station);
+    }
+}

--- a/tests/SpaceStationMonitor.Tests/RepairSystemAsyncTests.cs
+++ b/tests/SpaceStationMonitor.Tests/RepairSystemAsyncTests.cs
@@ -21,6 +21,51 @@ public class RepairSystemAsyncTests
     }
 
     [Fact]
+    public void BeginRepair_DoesNotPolluteActivityCurrent()
+    {
+        using var listener = StartListener();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repair = new RepairSystem(strategy);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
+
+        using var outerActivity = Telemetry.ActivitySource.StartActivity("OuterScope");
+        var beforeCurrent = Activity.Current;
+        Assert.Same(outerActivity, beforeCurrent);
+
+        var entry = repair.BeginRepair(sub, requested: 20);
+
+        // Activity.Current must be restored after BeginRepair: leaving the in-flight
+        // RepairAction as Current would invert StationCycle's parentage on the next
+        // cycle (researcher AC-16 — RepairAction is linked-from, not parented-to).
+        Assert.Same(beforeCurrent, Activity.Current);
+
+        entry.RepairAction?.Stop();
+    }
+
+    [Fact]
+    public void BeginRepair_StartsAsRoot_NotChildOfAmbientActivity()
+    {
+        using var listener = StartListener();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repair = new RepairSystem(strategy);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
+
+        using var outerActivity = Telemetry.ActivitySource.StartActivity("OuterScope");
+        Assert.NotNull(outerActivity);
+
+        var entry = repair.BeginRepair(sub, requested: 20);
+
+        Assert.NotNull(entry.RepairAction);
+        // RepairAction starts as a root span: distinct TraceId from the ambient outer
+        // activity. The link from each StationCycle to the in-flight RepairAction
+        // carries the cycle→repair causality without parent-of falsification.
+        Assert.NotEqual(outerActivity!.TraceId, entry.RepairAction!.TraceId);
+        Assert.Null(entry.RepairAction.Parent);
+
+        entry.RepairAction.Stop();
+    }
+
+    [Fact]
     public void BeginRepair_StartsActivity_WithExpectedTags()
     {
         using var listener = StartListener();

--- a/tests/SpaceStationMonitor.Tests/RepairSystemAsyncTests.cs
+++ b/tests/SpaceStationMonitor.Tests/RepairSystemAsyncTests.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using SpaceStationMonitor;
+using SpaceStationMonitor.BugStrategies;
+using Xunit;
+
+namespace SpaceStationMonitor.Tests;
+
+[Collection("ActivityListener-bound")]
+public class RepairSystemAsyncTests
+{
+    private static ActivityListener StartListener()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == Telemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    [Fact]
+    public void BeginRepair_StartsActivity_WithExpectedTags()
+    {
+        using var listener = StartListener();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repair = new RepairSystem(strategy);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
+
+        var entry = repair.BeginRepair(sub, requested: 20);
+
+        Assert.NotNull(entry.RepairAction);
+        var tags = entry.RepairAction!.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal("Oxygen", tags["subsystem.name"]);
+        Assert.Equal(20, tags["repair.requested"]);
+        Assert.Equal(entry.CyclesRemaining, tags["repair.cycles_required"]);
+
+        entry.RepairAction.Stop();
+    }
+
+    [Theory]
+    [InlineData(100.0, 1)]
+    [InlineData(99.0, 1)]
+    [InlineData(67.0, 1)]
+    [InlineData(66.9, 2)]
+    [InlineData(34.0, 2)]
+    [InlineData(33.9, 3)]
+    [InlineData(1.0, 3)]
+    public void BeginRepair_RollsCyclesBetween1And3(double health, int expectedCycles)
+    {
+        using var listener = StartListener();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repair = new RepairSystem(strategy);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = health };
+
+        var entry = repair.BeginRepair(sub, requested: 20);
+
+        Assert.Equal(expectedCycles, entry.CyclesRemaining);
+        Assert.InRange(entry.CyclesRemaining, 1, 3);
+
+        entry.RepairAction?.Stop();
+    }
+
+    [Fact]
+    public void CompleteRepair_AppliesHealth_AndStopsActivity()
+    {
+        using var listener = StartListener();
+        var strategy = new NoOpBugStrategy("Oxygen");
+        var repair = new RepairSystem(strategy);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
+
+        var entry = repair.BeginRepair(sub, requested: 20);
+        Assert.NotNull(entry.RepairAction);
+        Assert.False(entry.RepairAction!.Duration > TimeSpan.Zero);
+
+        var result = repair.CompleteRepair(entry);
+
+        Assert.Equal(20, result.Applied);
+        Assert.True(result.IsHealthy);
+        Assert.Equal(70.0, sub.Health);
+        Assert.True(entry.RepairAction.Duration > TimeSpan.Zero);
+
+        var tags = entry.RepairAction.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal(20, tags["repair.applied"]);
+        Assert.Equal(true, tags["repair.healthy"]);
+    }
+
+    [Fact]
+    public void CompleteRepair_OnLeak_SetsRepairHealthyFalse()
+    {
+        using var listener = StartListener();
+        var strategy = new LeakyRepairStrategy("Oxygen", TimeSpan.Zero);
+        // BugStrategyBase.IsBugActive checks elapsed since construction; sleep so any
+        // positive elapsed time clears the threshold deterministically.
+        Thread.Sleep(5);
+
+        var repair = new RepairSystem(strategy);
+        var sub = new Subsystem("Oxygen", 1.0) { Health = 50 };
+
+        var entry = repair.BeginRepair(sub, requested: 20);
+        var result = repair.CompleteRepair(entry);
+
+        Assert.False(result.IsHealthy);
+        Assert.True(result.Applied < result.Requested);
+
+        var tags = entry.RepairAction!.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal(false, tags["repair.healthy"]);
+        var leakEvent = entry.RepairAction.Events.FirstOrDefault(e => e.Name == "RepairLeak");
+        Assert.NotEqual(default, leakEvent);
+    }
+}

--- a/tests/SpaceStationMonitor.Tests/RetryStormStrategyTests.cs
+++ b/tests/SpaceStationMonitor.Tests/RetryStormStrategyTests.cs
@@ -151,15 +151,22 @@ public class RetryStormStrategyTests
         });
         listener.Start();
 
-        // Station with a single per-cycle quota slot — the retries should
-        // chew through it and trip the denied counter.
-        var station = new Station(repairsPerCycle: 1);
+        // Single retry budget: AlwaysFailingRetryStorm fails on every attempt, so the
+        // retry loop should consume the budget and trip the denied counter.
+        int retriesRemaining = 1;
+        bool TryConsumeRetry()
+        {
+            if (retriesRemaining <= 0) return false;
+            retriesRemaining--;
+            return true;
+        }
+
         var strategy = new AlwaysFailingRetryStorm();
         var repair = new RepairSystem(strategy);
         var sub = new Subsystem(TestSubsystem, 1.0) { Health = 50 };
 
         Assert.Throws<GeneralSpaceStationException>(() =>
-            repair.Repair(sub, 20, station.TryConsumeRepair));
+            repair.Repair(sub, 20, TryConsumeRetry));
 
         listener.Dispose();
 

--- a/tests/SpaceStationMonitor.Tests/StationTests.cs
+++ b/tests/SpaceStationMonitor.Tests/StationTests.cs
@@ -102,58 +102,29 @@ public class StationTests
     }
 
     [Fact]
-    public void NewStation_StartsWith3RepairsRemaining()
+    public void NewStation_StartsWith3FreeSlots()
     {
         var station = new Station();
 
-        Assert.Equal(3, station.RepairsRemainingThisCycle);
+        Assert.Equal(3, station.ActiveRepairs.AvailableSlots);
+        Assert.Equal(0, station.ActiveRepairs.InFlightCount);
     }
 
     [Fact]
-    public void TryConsumeRepair_DecrementsCounter()
+    public void Station_RespectsCustomConcurrentRepairs()
     {
-        var station = new Station();
+        var station = new Station(concurrentRepairs: 1);
 
-        Assert.True(station.TryConsumeRepair());
+        Assert.Equal(1, station.ActiveRepairs.AvailableSlots);
 
-        Assert.Equal(2, station.RepairsRemainingThisCycle);
-    }
-
-    [Fact]
-    public void TryConsumeRepair_ReturnsFalseWhenExhausted()
-    {
-        var station = new Station();
-
-        Assert.True(station.TryConsumeRepair());
-        Assert.True(station.TryConsumeRepair());
-        Assert.True(station.TryConsumeRepair());
-        Assert.False(station.TryConsumeRepair()); // 4th attempt fails
-        Assert.Equal(0, station.RepairsRemainingThisCycle);
-    }
-
-    [Fact]
-    public void StartNewCycle_ResetsRepairsRemaining()
-    {
-        var station = new Station();
-        station.TryConsumeRepair();
-        station.TryConsumeRepair();
+        var entry = new InFlightRepair(station.Subsystems[0], Requested: 20, CyclesRemaining: 1, RepairAction: null);
+        Assert.True(station.ActiveRepairs.TryStart(entry));
+        Assert.Equal(0, station.ActiveRepairs.AvailableSlots);
+        Assert.Equal(1, station.ActiveRepairs.InFlightCount);
 
         station.StartNewCycle(isBugActive: false);
-
-        Assert.Equal(3, station.RepairsRemainingThisCycle);
-    }
-
-    [Fact]
-    public void Station_RespectsCustomRepairsPerCycle()
-    {
-        var station = new Station(repairsPerCycle: 1);
-
-        Assert.Equal(1, station.RepairsRemainingThisCycle);
-        Assert.True(station.TryConsumeRepair());
-        Assert.False(station.TryConsumeRepair());
-
-        station.StartNewCycle(isBugActive: false);
-        Assert.Equal(1, station.RepairsRemainingThisCycle);
+        // Slot count is concurrent, not per-cycle: starting a new cycle does not free slots.
+        Assert.Equal(0, station.ActiveRepairs.AvailableSlots);
     }
 
     [Fact]
@@ -161,8 +132,8 @@ public class StationTests
     {
         // Mean ratio is ~3.14, not 4. Variance is additive (offset +0.4), so it
         // dilutes the multiplicative effect. Asymmetric window reflects per-run noise.
-        var stationLow = new Station(repairsPerCycle: 3, degradationMultiplier: 0.5);
-        var stationHigh = new Station(repairsPerCycle: 3, degradationMultiplier: 2.0);
+        var stationLow = new Station(concurrentRepairs: 3, degradationMultiplier: 0.5);
+        var stationHigh = new Station(concurrentRepairs: 3, degradationMultiplier: 2.0);
         stationLow.StartNewCycle(isBugActive: false);
         stationHigh.StartNewCycle(isBugActive: false);
 
@@ -189,9 +160,9 @@ public class StationTests
     public void Station_DefaultDegradationMultiplier_PreservesNoArgBehavior()
     {
         var stationNoArg = new Station();
-        var stationExplicit = new Station(repairsPerCycle: 3, degradationMultiplier: 1.0);
+        var stationExplicit = new Station(concurrentRepairs: 3, degradationMultiplier: 1.0);
 
-        Assert.Equal(stationExplicit.RepairsRemainingThisCycle, stationNoArg.RepairsRemainingThisCycle);
+        Assert.Equal(stationExplicit.ActiveRepairs.AvailableSlots, stationNoArg.ActiveRepairs.AvailableSlots);
         Assert.Equal(stationExplicit.EmergencyPowerRemaining, stationNoArg.EmergencyPowerRemaining);
         Assert.Equal(stationExplicit.HullIntegrity, stationNoArg.HullIntegrity);
         Assert.Equal(stationExplicit.Subsystems.Length, stationNoArg.Subsystems.Length);


### PR DESCRIPTION
## Why this change

> The elegant emergent property — Expert N=1 *is* the single-commitment shape.

(researcher §3, v2 spec)

The mechanic is **N concurrent repair slots**, where N is the per-difficulty WIP cap from `DifficultyTuning.For(difficulty).RepairsPerCycle` — Tutorial 4, Normal 3, Hard 2, Expert 1. Pressing R on the selected subsystem starts a repair if a slot is free; rejects with `All hands busy.` otherwise. Each repair occupies its slot for 1-3 cycles by damage tier and completes back into the existing telemetry surface. Bonded #9 fold-in adds an `ActivityLink` from each `CascadeCheck` Activity back to the `SubsystemTick` that triggered it.

The slot abstraction collapses the v1 dual-limit (per-cycle quota + queue capacity) into a single source of truth — N hands, each occupied for the duration of its repair. Harder difficulty means fewer hands means tighter strategic decisions: at Expert N=1, every R-press is a hard commitment. The slot count tunes both gameplay tempo and commitment density through one knob.

## Impact if not merged

Players stay locked into immediate-only repair, the OTel teaching beat for multi-cycle Activity lifetime + `ActivityLink` (past work + same-cycle causality) doesn't ship, and Sprint 004 close-out blocks. Bonded ship is intentional: splitting B3 from #9 would leave half the link-primitive lesson surface in place without the other half.

## Behavior

- **Press R**: start a repair on the selected subsystem if a slot is free (and that subsystem isn't already under repair). Cycles required = `Math.Clamp((100 - Health) / 33, 1, 3)`, locked at start. Player message: `Started repair on {sub}.`
- **Press R when saturated**: reject with `All hands busy.`; `Telemetry.RepairsDenied` increments with `subsystem.name` tag. The `RepairAction` Activity that `BeginRepair` started is stopped immediately with `status=Error, "rejected"` so it doesn't leak across cycles.
- **Press C**: cancel the oldest in-flight repair on the selected subsystem. Emits a `RepairCancelled` span event with `cancellation.reason="player_cancel"`, sets `status=Error, "cancelled"`, stops the Activity, and increments `Telemetry.RepairsFailed` with `cancellation.reason` for queryable counter dimensionality. Player messages: `Cancelled repair on {sub}.` / `Nothing to cancel on {sub}.`
- Each `StationCycle` while a repair is in flight carries an outgoing `ActivityLink` to that repair's context. Each `CascadeCheck` carries an outgoing link to the source `SubsystemTick` (parent-of would falsify parentage; a link is the right primitive).

## Mechanics

- **`ActiveRepairs`** (`src/SpaceStationMonitor/ActiveRepairs.cs`) holds the slot pool. Sized at construction from `concurrentRepairs`. No `Capacity` accessor (the cap is constructor-fixed; consumers read `AvailableSlots`). `TryStart` rejects on slot exhaustion OR same-subsystem-already-in-flight. `TryCancelOldestOn(target)` removes the oldest matching entry. `InFlightCount`, `AvailableSlots`, `InFlight`, `DecrementAll`, `DrainCompleted` round out the surface.
- **`InFlightRepair`** record: `(Subsystem, Requested, CyclesRemaining, RepairAction)`. Same shape as the v1 entry; renamed to fit the abstraction.
- **`RepairSystem.BeginRepair`** rolls cycles, starts a long-lived `RepairAction` Activity with `subsystem.name`, `repair.requested`, `repair.cycles_required` tags, returns the `InFlightRepair`. **`CompleteRepair`** runs the unchanged `Repair(...)` retry loop, applies `repair.applied`/`repair.healthy` tags, fires the `RepairLeak` event on partial repair, stops the Activity in `finally`. The leak / RetryStorm pathology is preserved verbatim.
- **`GameLoop`** builds the in-flight link list before `StartActivity` and passes via `links:`. Drain step (`DecrementAll` + `DrainCompleted` + `CompleteRepair` + histogram + log) runs immediately after `StartNewCycle`. Cascade loop links each `CascadeCheck` to `tickActivities[cascade.SourceSubsystem]` (the dict is keyed by `sub.Name`, not `actualTarget.Name` — this preserves the `WrongTargetDegradationStrategy` regression test from `a4a4fe8`).
- **`Station`** ctor parameter renamed `repairsPerCycle` → `concurrentRepairs`. `RepairsRemainingThisCycle` and `TryConsumeRepair()` deleted. `ActiveRepairs` exposed as a public property (sized from `concurrentRepairs`).

## HUD (50-col)

```
[1-4] Select [R] Repair [C] Cancel [E] Emerg Pwr
[Q] Quit  Emerg: 3    Smp: idle
Cycle: 42  |  Score: 1240  |  Hands: 2/4
```

- Footer N+3: `Cycle: {n} | Score: {n} | Hands: {n}/{cap}`. `Sel:` cell dropped (selection lives on the subsystem row's `▶` indicator). `Hands` value renders **Yellow at saturation** (`n == cap`) so the player can glance at the cell and know whether pressing R will succeed without parsing the numbers. **In-flight repair state surfaces only via this cell** — per UI lead's deduplication direction at visual conformance review.
- Footer N+2: emergency power counter + sampler badge. The v1 `Repairs: N` cell is gone (its source `RepairsRemainingThisCycle` was deleted under the slot model).
- Hotkey row: adds `[C] Cancel` between `[R] Repair` and `[E] Emerg Pwr`.

## Telemetry

- `station.repairs.denied` description string updated from `"per-cycle quota"` to `"no free repair slot"`. **Counter name and wire format unchanged.**
- `station.repairs.failed` gains a `cancellation.reason="player_cancel"` tag dimension when emitted from the cancellation path. Existing leak-failure emissions are unchanged (no tag).
- All other Activity sites, span tags, link emission, and the bonded #9 cascade-tick link surface are unchanged.

## Tests

- **`ActiveRepairsTests`** (8): capacity + same-subsystem rules on `TryStart`, slot arithmetic invariant, `DecrementAll` + `DrainCompleted` + `TryCancelOldestOn` semantics.
- **`RepairSystemAsyncTests`** (4 + Theory): `BeginRepair` tags + cycle-roll boundaries (1-3 by damage tier), `CompleteRepair` health apply + Activity stop, leak path with `RepairLeak` event.
- **`GameLoopAsyncRepairTests`** (4): completion after rolled cycles, in-flight `ActivityLink` on `StationCycle` (the bonded #9 canary — `InFlightRepair_AddsLinkToStationCycle`), terminal tags + Activity stop, cancel-error path with `RepairCancelled` event + `cancellation.reason` tag.
- **`GameLoopCascadeLinkTests`** (3): cascade ↔ source-tick link under `NoOp`, the divergent path under `WrongTargetDegradationStrategy` (the `a4a4fe8` regression test), and the no-link path when the source tick is sampled out.
- **`ActivityListenerCollection`**: xUnit `[CollectionDefinition(DisableParallelization = true)]` for the listener-bound tests. .NET `ActivitySource` sampling is OR'd across all registered listeners (any-says-yes wins), so a parallel test's `AllData` listener would invalidate another test's `None` decision. Serialization is the only reliable fix without exposing internals.
- **`StationTests`**: the v1 `RepairsRemainingThisCycle` / `TryConsumeRepair` tests are deleted (the abstraction they encoded is gone). New coverage targeting `ActiveRepairs.AvailableSlots` directly. Test count for this class shrinks slightly — that's correct, the new tests are tighter.
- **`RetryStormStrategyTests`**: the quota-exhaustion test rebound to a local `TryConsumeRetry` closure (the `Repair(...)` `tryConsumeQuota` parameter is preserved; the `Station`-sourced quota callback is gone).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` green (211 / 211)
- [x] Spot-check: `dotnet test --filter "FullyQualifiedName~ActiveRepairs"` green
- [x] Spot-check: `dotnet test --filter "FullyQualifiedName~Station"` green
- [x] Spot-check: `GameLoopAsyncRepairTests.InFlightRepair_AddsLinkToStationCycle` green (bonded #9 canary)
- [ ] Interactive smoke: at Expert (N=1), press R; press R again with one in flight → `All hands busy.` + Hands cell renders Yellow.
- [ ] Interactive smoke: press R, then C → `Cancelled repair on {sub}.`; verify `RepairCancelled` span event in Aspire with `cancellation.reason="player_cancel"`.
- [ ] Interactive smoke: force a cascade (drop a subsystem below 30); verify `CascadeCheck` activity has an `ActivityLink` to the source `SubsystemTick`. Repeat with `BUG_STRATEGY=WrongTargetDegradation` to verify the regression-test path holds at runtime.

## Out of scope (per researcher v2 §7)

- Renaming `DifficultyTuning.RepairsPerCycle` → `DifficultyTuning.ConcurrentRepairs` (touch radius across B1/B2 surfaces too large; follow-up ticket).
- New `in_flight.count` gauge or other new telemetry surface.
- Changes to `RepairSystem.Repair(...)` retry-loop behaviour (the leak bug is intentional and stays).
- Recomputing `cyclesRequired` mid-repair as the subsystem degrades.
- 80-col HUD redesign (locked decision (C); trigger remains Crew + Tasks).
- Cancellation telemetry from non-player paths (event-engine destroy/disable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
