### PR TITLE
docs: Sprint 004 cheat-sheet additions (multi-cycle Activities, ActivityLink lineage, asymmetric dedup tags)

### DIFF
--- a/docs/bug-catalog-debugging.md
+++ b/docs/bug-catalog-debugging.md
@@ -94,7 +94,7 @@ Each section has the symptom you'll notice as a player, then a numbered walkthro
 **Symptom:** repair quota runs out fast. "No repairs left" shows up even though you only pressed R once.
 
 1. Open Metrics. Pull the rate for `station.repairs.total`. How does it compare to how often you actually pressed R?
-2. Now look at `station.repairs.denied`. Is it climbing too? What does the `denied / total` ratio look like, and is it stable?
+2. Now look at `station.repairs.denied`. Is it climbing too? The counter description names three rejection paths: no free slot, repair already in flight on the same subsystem, and retry-quota exhaustion. RetryStorm fires on the third path; the first two fire from the slot-check at press time and are not the bug. Compare the rate of `denied` to the rate of `total` and the rate of times you actually pressed R. If `denied / total` is stable and `total / press-count` is high, you are looking at retries inside a single attempt rather than at slot rejections.
 3. Open Traces, filter by name=`RepairAction` over a 30-second window. How many spans show up versus how many times you clicked? Look for `repair.attempt` span events and the `attempt.outcome` tag (success, failure, denied).
 4. Filter logs by "quota exhausted". How many entries show up inside a single cycle? Is one user click producing one entry, or many?
 
@@ -135,6 +135,8 @@ A head sampler can never decide on a tag it has not seen yet. That is the whole 
 3. The trace shows the actual `RepairAction` span where the bug fired. From there, the usual span-events / tags / linked logs walk applies.
 4. If exemplars are missing on a bucket you expected to find one in, check that the head sampler at game start was not `AlwaysOff` and that the trace was not dropped by tail sampling.
 
+**B2 / D3 cross-reference.** Sprint 004 shipped two more sampler-vs-counter teaching beats that ride this same axis. Game Modes × Difficulty (B2) shipped per-mode sampler profiles: the head-sampling regime the player operates under is selected at game start by their mode pick. JustPlaying defaults to the hull-driven sampler from Sprint 002; Learning defaults to the env-resolved tail-sampling profile. The SamplingBlindSpot walkthrough and the head-vs-tail framing here apply across all profiles unchanged. The OrphanSpan strategy (D3) extends the `Context propagation` section: a span emitted as a root locally can carry a non-default `parent_span_id` if upstream propagation injected one, and the strategy fakes this to teach the `Parent is null && ParentSpanId == default` true-root test. If a sampler in your pipeline treats `Parent is null` as "this is the root, flush now," the strategy will surface that bug as premature flushes on the orphan-tagged spans.
+
 *Teaches: head and tail sampling answer different questions. Exemplars are the metric → trace bridge that keeps a low sample rate from hiding the trace you actually want. Production tail sampling lives in the collector; the in-game implementation is a single-process simulation.*
 
 ---
@@ -153,11 +155,57 @@ A trace can span multiple processes. Each process sees only its own slice; the t
 
 **Likely cause:** the activity was started with a remote parent context (correct propagation from an upstream service). The local process is a downstream service in a multi-process trace.
 
-**Common bug:** tail samplers, exporters, or correlation middleware that treat `Parent is null` as "this is THE trace root". That assumption holds in a single-process app and breaks at every internal service in a multi-process system. The remote-parented activity gets flushed prematurely, before its in-process children finish, because the buffer thinks it has seen the trace's root. Use `Parent is null && ParentSpanId == default` to test for a true local root.
+**Common bug:** tail samplers, exporters, or correlation middleware that treat `Parent is null` as "this is THE trace root". That assumption holds in a single-process app and breaks at every internal service in a multi-process system. The remote-parented activity gets flushed prematurely, before its in-process children finish, because the buffer thinks it has seen the trace's root. Use `Parent is null && ParentSpanId == default` to test for a true local root. For an example of a span that shows the false-root shape live in this codebase, set `BUG_STRATEGY=OrphanSpan` and watch the cycle exporter. Root spans with `parent_span_id != default` are exactly the failure mode this test guards against, and the strategy walks the player through it.
 
 **Completion signal for cross-process traces.** Root-end + grace works in a single-process app because every trace's root is observable locally. A remote-parented trace never sees its true root end, so the buffer needs a different completion signal. The one this codebase ships is an inactivity timeout: when no activity has been added to a buffered trace for a configurable window, flush. Real production tail samplers in the OpenTelemetry Collector use cross-process trace assembly (and a timeout fallback) for the same reason.
 
 *Teaches: `Parent is null` is not the same as 'trace root' once W3C propagation is in play.*
+
+---
+
+## Multi-cycle Activities
+
+Most spans wrap a synchronous block: open the `using`, do the work, the `Dispose()` stops the Activity. The `RepairAction` span breaks that pattern on purpose. A repair takes 1-3 cycles to apply (the cycle count is computed from how damaged the subsystem is), so the `Activity` is started when you press R and stopped when one of four things happens 1-3 cycles later.
+
+**Symptom:** an Activity has start and stop sites in different methods on different cycles, and the press-time stack is not the stack the stop runs on.
+
+**Look at:** `RepairAction` spans whose start timestamp lands in cycle N and whose stop timestamp lands in cycle N+1, N+2, or N+3. In the trace, walk the `StationCycle` spans during that window. None of them parent `RepairAction`; they each carry a `Link` to it instead.
+
+**Likely cause (intentional, here):** the work the span describes really does outlive the cycle in which it began. The two-cycle commit was a deliberate game-design choice, but the same shape shows up in real systems any time you start an Activity at request-acceptance and stop it at request-completion (long-running jobs, batch workflows, async retries with backoff).
+
+**Common bug:** starting an Activity in one method and forgetting to stop it on every exit path. `RepairAction` has four stop sites and every one is load-bearing:
+- **Completion.** The repair finishes naturally; `CompleteRepair` runs in a `finally` so even an exception path stops the Activity.
+- **Player cancel.** Pressing C on a subsystem with an in-flight repair. Adds a `RepairCancelled` event with `cancellation.reason="player_cancel"`, then stops.
+- **Reject at start.** A repair was attempted but no slot was free or the subsystem already has a repair in flight. The Activity is started before the slot check, so the rejection itself is observable as a span. The reject path then sets status `rejected` and stops the Activity immediately.
+- **Shutdown.** Ctrl+C or hull-zero game-over while a repair is in flight. The cycle loop's `finally` walks every in-flight entry and stops each Activity with `cancellation.reason="shutdown"`.
+
+Miss any of these and you ship orphan spans: Activities that never call `Stop()`, never get exported, and surface as "in-progress" forever in dashboards that expect end-time.
+
+**Activity.Current discipline.** Starting a long-lived Activity has a second hazard: `Activity.Current` is ambient. If the calling thread is inside a `StationCycle` Activity at press-time and you call `StartActivity("RepairAction", ...)` directly, the new Activity inherits `StationCycle` as its parent, which is wrong here: `RepairAction` outlives the cycle and would prematurely-close the cycle's tail. The fix is the press-time null-pivot: capture `Activity.Current`, set it to `null`, start the new Activity (which now starts as a true root), then restore the captured `Current` in a `finally`. The `finally` matters because a throw from `StartActivity` or any tag-set in between would otherwise leak the null `Current` into the caller's ambient context.
+
+*Teaches: an Activity's lifetime is bound to the call to `Stop()`, not to the lexical scope where it was started. When the work outlives the lexical scope, every exit path needs a stop call. `Activity.Current` is ambient and inherited by new Activities started under it, so a long-lived span that should be a root needs an explicit null-pivot/restore around `StartActivity` to avoid prematurely-closing whatever Activity was current at press-time.*
+
+---
+
+## ActivityLink as causal lineage
+
+Parent-of is the strong relationship: it asserts `B is a child of A`, which means A's lifetime contains B's lifetime and the trace tree shows B as a sub-step of A. `ActivityLink` is the weak one: it says `B is causally related to A` without claiming containment or parentage. Two distinct relationships, two different question shapes a query can answer.
+
+The space station has two cases where parent-of would falsify the relationship and a `Link` is the right tool.
+
+**Symptom:** spans that are causally related (one triggered the other) but where the trigger's lifetime is not strictly contained inside the triggered span's lifetime, OR where the relationship is many-to-one and parentage would fork the trace tree.
+
+**Pattern A: `StationCycle` links to in-flight `RepairAction`.** Each cycle, before starting the `StationCycle` span, the loop walks `_station.ActiveRepairs.InFlight` and builds an `ActivityLink` list pointing at each in-flight `RepairAction`'s context. The links are passed to `StartActivity(..., links: inFlightLinks)`. The cycle is not a child of any repair (the repair started 1-2 cycles earlier), and the repair is not a child of this cycle (it might outlive the cycle by 1-2 more). Parent-of would lie either direction. Link carries "this cycle relates to that repair" without falsifying the tree.
+
+**Pattern B: `CascadeCheck` links to source `SubsystemTick`.** When a cascade fires, the `CascadeCheck` span is a child of the current `StationCycle` (same cycle, contained lifetime; parentage is correct). But the cascade was *triggered by* a specific `SubsystemTick` earlier in this cycle's tick loop. The trigger relationship is causal, not containment: the tick already completed by the time the cascade check runs. So `CascadeCheck` is parented to `StationCycle` and additionally `Link`s back to the source tick. The dictionary keying the tick-by-name is keyed by `sub.Name` (the original subsystem the loop iterated over), not the redirected target. Under `WrongTargetDegradationStrategy` the two diverge, and the keying choice preserves the cascade's true source.
+
+**Look at:** in the trace UI, a span with `Link` count > 0 and a parent-of edge to its lexical parent. The Link list is a separate panel; it's a peer-of-parent relation, not a child relation.
+
+**Likely cause:** the relationship is causal-but-not-containment. Parent-of would either invert lifetimes (Pattern A) or claim a child relationship that the runtime invariant forbids (Pattern B).
+
+**Common bug:** treating `Link` as a weaker version of parent-of and reaching for it whenever parent-of feels awkward. It is not. `Link` does not propagate context the way parent-of does (samplers and exporters do not follow links the way they follow parent edges). If A really is the parent of B, use parent-of. Reach for `Link` only when parent-of would falsify the relationship.
+
+*Teaches: parent-of asserts containment; `ActivityLink` asserts causal relation without containment. Pick by the runtime invariant the spans need to honor, not by what's convenient at the call site. The two link patterns this codebase uses (cycle → in-flight repair, cascade → source tick) are the two canonical shapes you will hit in real systems: long-lived work spans and cross-step causality within a single workflow.*
 
 ## Semantic conventions
 
@@ -172,3 +220,23 @@ OpenTelemetry maintains a Semantic Conventions spec for exactly this reason: to 
 **Likely cause:** the same logical dimension is emitted under inconsistent keys (e.g. `subsystem.name` vs `subsystem`) across cycles, services, or refactors.
 
 *Teaches: attribute keys are a typed contract; the time to enforce it is at the emission boundary, not after a dashboard quietly under-counts for a week.*
+
+---
+
+## Asymmetric tags as dedup keys
+
+Two error sites can both legitimately increment the same counter. The inner site is the one most queries want to count. The outer site catches the tail of an unhandled exception that escaped the inner; without it, exceptions on rare code paths drop silently and the counter under-reports. With it, common-bail paths double-count: the inner increments once, the inner re-throws, the outer catches it and increments again.
+
+**Symptom:** a counter total that's exactly 2× what your operator intuition expects, on the paths where an exception escapes the inner handler.
+
+**Look at:** the two catch sites that both touch the same counter. Are they both unconditionally incrementing? Is one of them tagging the increment with something the other doesn't?
+
+**Likely cause:** the outer-catch is an exception-safety net, not a separate event class. It exists so the counter doesn't under-report on rare paths. On common paths, both sites fire and the total inflates.
+
+**Pattern this codebase uses:** the outer-catch tags its increment with `failure.layer="outer"`. The inner-catch sites do not set the tag. Standard query convention: `RepairsFailed{failure.layer != "outer"}` returns one count per unique attempt; the unfiltered total includes the outer safety net for the rare paths inner missed. Both queries are useful, and they answer different questions.
+
+**Why asymmetric and not balanced.** An alternative is to tag both sites: `failure.layer="inner"` on the inner catch, `failure.layer="outer"` on the outer. That works but inflates the contract: now every inner-catch site has to remember to set the tag, and forgetting it drops a measurement out of either query. The asymmetric shape leaves inner sites alone and tags only the outer; the deduplication cost lives at exactly one site, the one that knows it might double-count.
+
+**Cancellation paths use a different tag.** Player-cancel and shutdown also increment `station.repairs.failed` because they end an Activity that didn't complete. They tag with `cancellation.reason` (`player_cancel` / `shutdown`), not `failure.layer`. Different tag for a different reason class: a cancelled repair isn't a "failure layer", it's a structured exit. The asymmetric pattern handles double-count dedup; the cancellation tag handles "what kind of non-success was this". Both tags live on the same `station.repairs.failed` counter; they answer orthogonal questions ("did this double-count from the safety net?" vs "what kind of non-success was this?") and a query can filter on either or both.
+
+*Teaches: when two emission sites legitimately count the same event class, an asymmetric marker tag at exactly one site preserves both query shapes (raw total, deduplicated total) without forcing every site to participate in the contract. Reach for asymmetric tagging when the deduplication cost is concentrated at one site (the safety net), not distributed across many.*


### PR DESCRIPTION
## Summary

Sprint 004 close-out documentation deliverable. Verbatim merge of approved v3 cheat-sheet draft (`Research/2026-04-30-sprint-004-cheat-sheet-v3.md`, PM-greenlit 2026-05-01) into the live bug-catalog. Closes the QA-flagged gap (`Test Results/2026-05-01-sprint-004-end-qa.md` row 86 — multi-cycle `RepairAction` lifetime + both `ActivityLink` patterns uncovered) and adds three more S4 teaching beats. Bundled with `Project Management/2026-05-01-sprint-004-retro.md` per S4 close-out fan-out.

## 7 blocks applied

To `docs/bug-catalog-debugging.md`:

1. **Block 1 — new section `## Multi-cycle Activities`** (after Context propagation, before Semantic conventions). Covers `RepairAction` start-at-press / stop-on-completion-or-cancel-or-reject-or-shutdown lifetime, the four load-bearing stop sites, and the `Activity.Current` null-pivot/restore discipline.
2. **Block 2 — new section `## ActivityLink as causal lineage`** (after Multi-cycle Activities, before Semantic conventions). Pattern A (`StationCycle` ↔ in-flight `RepairAction`) and Pattern B (`CascadeCheck` ↔ source `SubsystemTick`); when parent-of would falsify the relationship.
3. **Block 3 — new section `## Asymmetric tags as dedup keys`** (after Semantic conventions). The `failure.layer="outer"` outer-only marker tag, why asymmetric beats balanced, and how `cancellation.reason` lives orthogonally on the same `station.repairs.failed` counter.
4. **Block 4 — in-place expand RetryStorm step 2** with the three `station.repairs.denied` rejection paths (no free slot / repair already in flight on subsystem / retry-quota exhaustion).
5. **Block 5 — in-place B2 / D3 cross-reference paragraph** appended to the Sampling head-vs-tail section before its closing `*Teaches:*` footer. Per-mode sampler profile axis (B2 ties profile to mode, not difficulty) and OrphanSpan as a parent-shape teaching beat (D3).
6. **Block 6 — in-place sentence** appended to the `**Common bug:**` paragraph of Context propagation: `BUG_STRATEGY=OrphanSpan` as a live example of the false-root shape the `Parent is null && ParentSpanId == default` test guards against.
7. **Block 7 — cross-doc verify on `CLAUDE.md`** lines 66-86. The span-topology block already documents the four `RepairAction` stop sites and both `ActivityLink` patterns. **No edit needed**; doc and code already line up.

## Citation chain

- Source code on `main` at `1a9219c`: `RepairSystem.cs`, `GameLoop.cs`, `Telemetry.cs`, `ActiveRepairs.cs`, `Sampling/SamplerProfileFactory.cs`, `Program.cs`.
- QA evidence: `Test Results/2026-05-01-sprint-004-end-qa.md` rows 4a-4c, 5, 6, 7, 47, 48, 50; observation 86.
- Source-of-truth doc: `Research/2026-04-30-sprint-004-cheat-sheet-v3.md` (approved, locked PM decisions both rounds in-doc).

## Out-of-scope this pass (banked for next doc-touch)

Per the v3 §"Doc-hygiene side-notes" and the task brief:

- Em-dash legacy 3 in the SamplingBlindSpot section (lines 111, 113, 115) — pre-`feedback_three_surfaces_hygiene` shipped content, not folded here. New v3 additions hold the no-em-dash line.
- Slot codename `` `B2` `` (line 113) → player-facing label normalize. Block 5 follows existing `` `B2` `` precedent; whole-doc normalize-pass surfaced for S5+.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors (doc-only change, sanity verified)
- [x] Em-dash hygiene held on all new content (only legacy 3 remain, all out-of-scope)
- [x] Section ordering matches v3 placement instructions: Context propagation → Multi-cycle Activities → ActivityLink as causal lineage → Semantic conventions → Asymmetric tags as dedup keys
- [x] CLAUDE.md span-topology cross-doc check confirms alignment (Block 7, no edit)
- [ ] Reviewer pool double-clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)